### PR TITLE
update mdserver-web

### DIFF
--- a/apps/mdserver-web/data.yml
+++ b/apps/mdserver-web/data.yml
@@ -15,6 +15,6 @@ additionalProperties:
     crossVersionUpdate: true
     limit: 0
     recommend: 0
-    website: https://hub.docker.com/r/ddsderek/mw
+    website: https://hub.docker.com/r/ddsderek/mdserver-web
     github: https://github.com/midoks/mdserver-web
     document: https://github.com/midoks/mdserver-web/wiki/

--- a/apps/mdserver-web/latest/docker-compose.yml
+++ b/apps/mdserver-web/latest/docker-compose.yml
@@ -12,7 +12,7 @@ services:
         - "${phpMyAdmin_PORT}:888"
     volumes:
         - mw-server:/www
-    image: "ddsderek/mw:latest"
+    image: "ddsderek/mdserver-web:latest"
     labels:  
       createdBy: "Apps"
 volumes:


### PR DESCRIPTION
Fix docker url error. 
Docker of mdserver-web is now on https://hub.docker.com/r/ddsderek/mdserver-web