### PR TITLE
opti: add edit is true for log level config

### DIFF
--- a/apps/ikaros/0.16.1/data.yml
+++ b/apps/ikaros/0.16.1/data.yml
@@ -55,10 +55,11 @@ additionalProperties:
       rule: paramHttp
       type: text
     - default: "INFO"
+      edit: true
       envKey: SERVER_LOG_LEVEL
       labelEn: Core Server Package Log level
-      labelZh: 【高级】核心Server包日志级别
-      required: true
+      labelZh: 核心Server包日志级别
+      required: false
       type: select
       values:
         - label: DEBUG
@@ -72,10 +73,11 @@ additionalProperties:
         - label: CRITICAL
           value: "CRITICAL"
     - default: "INFO"
+      edit: true
       envKey: PLUGIN_LOG_LEVEL
       labelEn: Plugin Package Log level
-      labelZh: 【高级】插件包日志级别
-      required: true
+      labelZh: 插件包日志级别
+      required: false
       type: select
       values:
         - label: DEBUG


### PR DESCRIPTION
给日志级别的配置更改成了：

- 非必需
- 可编辑
- 去掉中文描述里的`【高级】`