### PR TITLE
Change GitHub mirror URL

### DIFF
--- a/README-en.md
+++ b/README-en.md
@@ -67,14 +67,14 @@ The default installation path of `1Panel` is `/opt/`, which can be modified as n
 
 > GitHub Acceleration Methods
 >> - (Added to this repository) Self-built: https://github.com/hunshcn/gh-proxy
->> - https://mirror.ghproxy.com
+>> - https://ghp.ci
 
 #### 2.1.1 Getting Apps via Git Command
 
 In the `Shell Script` task type in the `1Panel` scheduled tasks, add and execute the following command, or run the following command in the terminal:
 
 ```shell
-git clone -b localApps https://mirror.ghproxy.com/https://github.com/okxlin/appstore /opt/1panel/resource/apps/local/appstore-localApps
+git clone -b localApps https://ghp.ci/https://github.com/okxlin/appstore /opt/1panel/resource/apps/local/appstore-localApps
 
 cp -rf /opt/1panel/resource/apps/local/appstore-localApps/apps/* /opt/1panel/resource/apps/local/
 
@@ -88,7 +88,7 @@ Then refresh the local applications in the app store.
 In the `Shell Script` task type in the `1Panel` scheduled tasks, add and execute the following command, or run the following command in the terminal:
 
 ```shell
-wget -P /opt/1panel/resource/apps/local https://mirror.ghproxy.com/https://github.com/okxlin/appstore/archive/refs/heads/localApps.zip
+wget -P /opt/1panel/resource/apps/local https://ghp.ci/https://github.com/okxlin/appstore/archive/refs/heads/localApps.zip
 
 unzip -o -d /opt/1panel/resource/apps/local/ /opt/1panel/resource/apps/local/localApps.zip
 

--- a/README.md
+++ b/README.md
@@ -66,13 +66,13 @@
 
 > GitHub加速方式
 >> - (本仓库已添加)自建：https://github.com/hunshcn/gh-proxy
->> - https://mirror.ghproxy.com
+>> - https://ghp.ci
 
 #### 2.1.1 使用 git 命令获取应用
 
 `1Panel`计划任务类型`Shell 脚本`的计划任务框里，添加并执行以下命令，或者终端运行以下命令，
 ```shell
-git clone -b localApps https://mirror.ghproxy.com/https://github.com/okxlin/appstore /opt/1panel/resource/apps/local/appstore-localApps
+git clone -b localApps https://ghp.ci/https://github.com/okxlin/appstore /opt/1panel/resource/apps/local/appstore-localApps
 
 cp -rf /opt/1panel/resource/apps/local/appstore-localApps/apps/* /opt/1panel/resource/apps/local/
 
@@ -85,7 +85,7 @@ rm -rf /opt/1panel/resource/apps/local/appstore-localApps
 
 `1Panel`计划任务类型`Shell 脚本`的计划任务框里，添加并执行以下命令，或者终端运行以下命令，
 ```shell
-wget -P /opt/1panel/resource/apps/local https://mirror.ghproxy.com/https://github.com/okxlin/appstore/archive/refs/heads/localApps.zip
+wget -P /opt/1panel/resource/apps/local https://ghp.ci/https://github.com/okxlin/appstore/archive/refs/heads/localApps.zip
 
 unzip -o -d /opt/1panel/resource/apps/local/ /opt/1panel/resource/apps/local/localApps.zip
 


### PR DESCRIPTION
Due to the fact that ghproxy.com is not reachable in mainland China, and visits through global network will automatically be redirected to https://ghp.ci
<img width="417" alt="image" src="https://github.com/user-attachments/assets/391389a5-01a3-49e9-b931-727d1f8e3bd0">
reaching through global network

<img width="431" alt="image" src="https://github.com/user-attachments/assets/658dc4f2-0c17-4cd4-8e59-60ff22785321">
reaching through domestic network (CERNET)