### PR TITLE
chore: require dashboard approval for multi-service apps [openclaw]

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -328,13 +328,13 @@
     {
       "description": "Require dashboard approval for multi-service multi-image compose apps",
       "matchFileNames": [
-        "apps/safeline/**",
-        "apps/aurora/**",
-        "apps/immich/**",
-        "apps/udyk-ce/**",
-        "apps/zabbix-server/**",
-        "apps/next-terminal/**",
-        "apps/uuwaf/**"
+        "apps/safeline/**/docker-compose.yml",
+        "apps/aurora/**/docker-compose.yml",
+        "apps/immich/**/docker-compose.yml",
+        "apps/udyk-ce/**/docker-compose.yml",
+        "apps/zabbix-server/**/docker-compose.yml",
+        "apps/next-terminal/**/docker-compose.yml",
+        "apps/uuwaf/**/docker-compose.yml"
       ],
       "dependencyDashboardApproval": true
     }

--- a/renovate.json
+++ b/renovate.json
@@ -324,6 +324,19 @@
         "apps/n8n/2.5.*/*.yml"
       ],
       "allowedVersions": "/^2.5.*/"
+    },
+    {
+      "description": "Require dashboard approval for multi-service multi-image compose apps",
+      "matchFileNames": [
+        "apps/safeline/**",
+        "apps/aurora/**",
+        "apps/immich/**",
+        "apps/udyk-ce/**",
+        "apps/zabbix-server/**",
+        "apps/next-terminal/**",
+        "apps/uuwaf/**"
+      ],
+      "dependencyDashboardApproval": true
     }
   ],
   "prCreation": "immediate"


### PR DESCRIPTION
## What changed
- add a Renovate package rule that requires Dependency Dashboard approval for selected higher-risk multi-service compose apps
- scope the rule to `docker-compose.yml` files under the selected app paths only

## Scope
This rule applies to:
- safeline
- aurora
- immich
- udyk-ce
- zabbix-server
- next-terminal
- uuwaf

## Behavior
For these apps, Renovate will:
- still detect updates
- stop creating PRs automatically
- wait for manual approval from Dependency Dashboard before opening a PR
