### PR TITLE
chore: ignore Dockerfiles in Renovate [openclaw]

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,7 +10,8 @@
   "ignorePaths": [
     "apps/mysql-cluster/**",
     "apps/redis-cluster/**",
-    "apps/postgresql-cluster/**"
+    "apps/postgresql-cluster/**",
+    "**/Dockerfile"
   ],
   "packageRules": [
     {


### PR DESCRIPTION
## What changed
- add `**/Dockerfile` to Renovate `ignorePaths`

## Effect
- Renovate will ignore all Dockerfiles in this repository
- docker-compose and other existing Renovate rules remain unchanged
