### PR TITLE
fix: match renovate bot in automerge workflow [openclaw]

### DIFF
--- a/.github/workflows/renovate-automerge.yml
+++ b/.github/workflows/renovate-automerge.yml
@@ -18,7 +18,10 @@ jobs:
   automerge:
     if: >
       github.event.pull_request.state == 'open' &&
-      github.event.pull_request.user.login == 'app/renovate'
+      (
+        github.event.pull_request.user.login == 'app/renovate' ||
+        github.event.pull_request.user.login == 'renovate[bot]'
+      )
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## What changed
- update Renovate automerge workflow to accept both `app/renovate` and `renovate[bot]`

## Why
Recent Renovate PRs are being authored by `renovate[bot]`, so the automerge workflow was triggering but skipping at the job gate.

## Effect
- whitelisted Renovate PRs can now proceed through the existing whitelist + marker checks
- no change to the later merge conditions
