### PR TITLE
chore: allow reader automerge [openclaw]

### DIFF
--- a/.github/renovate-automerge-whitelist.txt
+++ b/.github/renovate-automerge-whitelist.txt
@@ -37,3 +37,4 @@ ikaros
 siyuan
 mt-photos
 nginxwebui
+reader

--- a/renovate.json
+++ b/renovate.json
@@ -34,12 +34,6 @@
     },
     {
       "matchFileNames": [
-        "apps/reader/2.7.*/*.yml"
-      ],
-      "allowedVersions": "/^2.7.*/"
-    },
-    {
-      "matchFileNames": [
         "apps/mysql/5.6.*/*.yml"
       ],
       "allowedVersions": "/^5.6.*/"
@@ -338,6 +332,13 @@
         "apps/uuwaf/**/docker-compose.yml"
       ],
       "dependencyDashboardApproval": true
+    },
+    {
+      "description": "Disable Renovate updates for reader 2.7.x",
+      "matchFileNames": [
+        "apps/reader/2.7.*/*.yml"
+      ],
+      "enabled": false
     }
   ],
   "prCreation": "immediate"


### PR DESCRIPTION
## What changed
- add `reader` to `.github/renovate-automerge-whitelist.txt`
- disable Renovate updates for `apps/reader/2.7.*/*.yml`

## Why
- `reader` should be allowed into automerge for other numeric version lines
- `reader/2.7.*` should remain frozen and not receive Renovate update PRs
