### PR TITLE
chore: sync watchtower with upstream [openclaw]

### DIFF
--- a/apps/watchtower/1.7.1/data.yml
+++ b/apps/watchtower/1.7.1/data.yml
@@ -10,7 +10,7 @@ additionalProperties:
     - default: --interval 3600 --cleanup
       edit: true
       envKey: COMMAND1
-      labelEn: Command parameters (separated by spaces)
-      labelZh: 命令参数(以空格分割)
+      labelEn: Command arguments (space-separated, single quotes not supported)
+      labelZh: 命令参数（以空格分隔，不支持单引号）
       required: true
       type: text

--- a/apps/watchtower/1.7.1/docker-compose.yml
+++ b/apps/watchtower/1.7.1/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
     environment:
       - TZ=Asia/Shanghai
+      - DOCKER_API_VERSION=1.52
       - ${ENV1}
     command: ${COMMAND1}
     image: containrrr/watchtower:1.7.1

--- a/apps/watchtower/latest/data.yml
+++ b/apps/watchtower/latest/data.yml
@@ -10,7 +10,7 @@ additionalProperties:
     - default: --interval 3600 --cleanup
       edit: true
       envKey: COMMAND1
-      labelEn: Command parameters (separated by spaces)
-      labelZh: 命令参数(以空格分割)
+      labelEn: Command arguments (space-separated, single quotes not supported)
+      labelZh: 命令参数（以空格分隔，不支持单引号）
       required: true
       type: text

--- a/apps/watchtower/latest/docker-compose.yml
+++ b/apps/watchtower/latest/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
     environment:
       - TZ=Asia/Shanghai
+      - DOCKER_API_VERSION=1.52
       - ${ENV1}
     command: ${COMMAND1}
     image: containrrr/watchtower


### PR DESCRIPTION
## What changed
- sync local watchtower app files with upstream watchtower behavior
- add `DOCKER_API_VERSION=1.52` to watchtower environment
- update command argument field text in `data.yml`

## Scope
- `apps/watchtower/1.7.1`
- `apps/watchtower/latest`
