### PR TITLE
feat: auto-label third-party PRs as pending [openclaw]

### DIFF
--- a/.github/workflows/label-third-party-prs.yml
+++ b/.github/workflows/label-third-party-prs.yml
@@ -1,0 +1,20 @@
+name: Label third-party PRs
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+
+permissions:
+  pull-requests: write
+
+jobs:
+  add-pending-label:
+    if: github.event.pull_request.user.login != 'app/renovate' && github.event.pull_request.user.login != 'renovate[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add pending label to third-party PRs
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          labels: pending


### PR DESCRIPTION
## What changed
- add a workflow to auto-label third-party PRs with `pending`
- workflow only applies to non-Renovate PRs
- no auto-commenting in this first version

## Trigger
- `pull_request_target`
- events: `opened`, `reopened`

## Guard
- skip `app/renovate`
- skip `renovate[bot]`
