### PR TITLE
chore: remove deprecated renovate input [openclaw]

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -21,5 +21,4 @@ jobs:
       - name: Run Renovate
         uses: renovatebot/github-action@68a3ea99af6ad249940b5a9fdf44fc6d7f14378b # v46.1.6
         with:
-          useSlim: false
           token: ${{ secrets.GITHUBTOKEN }}


### PR DESCRIPTION
## What changed
- remove deprecated `useSlim: false` from `.github/workflows/renovate.yml`

## Why
- current `renovatebot/github-action` no longer accepts `useSlim`
- keeping it causes noisy workflow warnings on every Renovate run
