### PR TITLE
chore: allow 2fauth and adguardhome automerge [openclaw]

### DIFF
--- a/.github/renovate-automerge-whitelist.txt
+++ b/.github/renovate-automerge-whitelist.txt
@@ -38,3 +38,5 @@ siyuan
 mt-photos
 nginxwebui
 reader
+2fauth
+adguardhome


### PR DESCRIPTION
## What changed
- add `2fauth`
- add `adguardhome`

to `.github/renovate-automerge-whitelist.txt`

## Why
- current Renovate PRs `#3577` and `#3578` are being explicitly accepted
- whitelist them for future automerge as well
