### PR TITLE
fix: freeze alist 3.44.0 updates [openclaw]

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -339,6 +339,13 @@
         "apps/reader/2.7.*/*.yml"
       ],
       "enabled": false
+    },
+    {
+      "description": "Disable Renovate updates for alist 3.44.0",
+      "matchFileNames": [
+        "apps/alist/3.44.0/*.yml"
+      ],
+      "enabled": false
     }
   ],
   "prCreation": "immediate"


### PR DESCRIPTION
## What changed
- add a Renovate rule to disable updates for `apps/alist/3.44.0/*.yml`

## Why
- keep the `3.44.0` line frozen
- leave room for other alist numeric versions to be handled separately later
