### PR TITLE
fix: repair automerge marker shell escaping [openclaw]

### DIFF
--- a/.github/workflows/renovate-automerge.yml
+++ b/.github/workflows/renovate-automerge.yml
@@ -103,9 +103,10 @@ jobs:
           echo "== compare commits =="
           echo "$COMPARE_COMMITS"
 
-          if printf '%s
-%s
-' "$PULL_COMMITS" "$COMPARE_COMMITS" | grep -Fq "Update app version [skip ci]"; then
+          ALL_COMMITS="$PULL_COMMITS
+$COMPARE_COMMITS"
+
+          if echo "$ALL_COMMITS" | grep -Fq "Update app version [skip ci]"; then
             echo "found=true" >> "$GITHUB_OUTPUT"
           else
             echo "found=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## What changed
- repair the marker check shell block in `.github/workflows/renovate-automerge.yml`
- avoid broken embedded newlines in the `printf` expression
- use a simpler combined string check instead

## Why
- the previous workflow edit left a malformed shell snippet in the workflow file
- that caused GitHub to treat the workflow as having a file issue during push evaluation
