### PR TITLE
fix: repair automerge marker line 107 [openclaw]

### DIFF
--- a/.github/workflows/renovate-automerge.yml
+++ b/.github/workflows/renovate-automerge.yml
@@ -103,8 +103,7 @@ jobs:
           echo "== compare commits =="
           echo "$COMPARE_COMMITS"
 
-          ALL_COMMITS="$PULL_COMMITS
-$COMPARE_COMMITS"
+          ALL_COMMITS="$(printf '%s\n%s\n' "$PULL_COMMITS" "$COMPARE_COMMITS")"
 
           if echo "$ALL_COMMITS" | grep -Fq "Update app version [skip ci]"; then
             echo "found=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## What changed
- replace the multiline `ALL_COMMITS` assignment in `.github/workflows/renovate-automerge.yml`
- use a safe `printf`-based assignment instead

## Why
- GitHub reports `Invalid workflow file: .github/workflows/renovate-automerge.yml#L107`
- the multiline shell assignment was causing workflow parsing failure
