### PR TITLE
fix: use dispatch pr number in merge flow [openclaw]

### DIFF
--- a/.github/workflows/renovate-automerge.yml
+++ b/.github/workflows/renovate-automerge.yml
@@ -88,7 +88,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUBTOKEN }}
         run: |
-          gh pr edit "${{ github.event.pull_request.number }}" \
+          PR_NUMBER="${{ github.event.pull_request.number || inputs.pr_number }}"
+          gh pr edit "$PR_NUMBER" \
             --repo "${{ github.repository }}" \
             --add-label renovate-auto
 
@@ -135,7 +136,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUBTOKEN }}
         run: |
-          gh pr merge "${{ github.event.pull_request.number }}" \
+          PR_NUMBER="${{ github.event.pull_request.number || inputs.pr_number }}"
+          gh pr merge "$PR_NUMBER" \
             --repo "${{ github.repository }}" \
             --merge \
             --delete-branch=false


### PR DESCRIPTION
## What changed
- pass `pr_number` through the label and merge steps during `workflow_dispatch`
- keep pull_request behavior unchanged

## Why
- manual dispatch already resolves PR number in whitelist and marker checks
- label/merge steps still referenced `github.event.pull_request.number`, which is empty for dispatch runs
