### PR TITLE
fix: retry automerge when base branch changes

### DIFF
--- a/.github/workflows/renovate-automerge.yml
+++ b/.github/workflows/renovate-automerge.yml
@@ -137,7 +137,31 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUBTOKEN }}
         run: |
           PR_NUMBER="${{ github.event.pull_request.number || inputs.pr_number }}"
-          gh pr merge "$PR_NUMBER" \
-            --repo "${{ github.repository }}" \
-            --merge \
-            --delete-branch=false
+          REPO="${{ github.repository }}"
+
+          for attempt in 1 2 3 4 5; do
+            echo "== merge attempt $attempt =="
+
+            set +e
+            MERGE_OUTPUT=$(gh pr merge "$PR_NUMBER" \
+              --repo "$REPO" \
+              --merge \
+              --delete-branch=false 2>&1)
+            MERGE_EXIT=$?
+            set -e
+
+            echo "$MERGE_OUTPUT"
+
+            if [ "$MERGE_EXIT" -eq 0 ]; then
+              exit 0
+            fi
+
+            if echo "$MERGE_OUTPUT" | grep -Fq "Base branch was modified"; then
+              if [ "$attempt" -lt 5 ]; then
+                sleep $((attempt * 5))
+                continue
+              fi
+            fi
+
+            exit "$MERGE_EXIT"
+          done

--- a/.github/workflows/renovate-automerge.yml
+++ b/.github/workflows/renovate-automerge.yml
@@ -156,6 +156,12 @@ jobs:
               exit 0
             fi
 
+            PR_STATE=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json state,mergedAt --jq 'if .mergedAt then "MERGED" else .state end' 2>/dev/null || true)
+            if [ "$PR_STATE" = "MERGED" ] || [ "$PR_STATE" = "CLOSED" ]; then
+              echo "PR already resolved with state: $PR_STATE"
+              exit 0
+            fi
+
             if echo "$MERGE_OUTPUT" | grep -Fq "Base branch was modified"; then
               if [ "$attempt" -lt 5 ]; then
                 sleep $((attempt * 5))


### PR DESCRIPTION
## Summary
- retry automerge when merge fails because the base branch advanced
- back off between retries instead of failing immediately
- treat already merged/closed PRs as success during retry checks

## Testing
- inspected workflow YAML
- validated recent automerge failures were caused by `Base branch was modified`
