### PR TITLE
[openclaw] fix local app import parse errors for 1Panel

### DIFF
--- a/apps/autoheal/latest/data.yml
+++ b/apps/autoheal/latest/data.yml
@@ -5,14 +5,5 @@ additionalProperties:
       envKey: ENV1
       labelEn: Environmental parameters
       labelZh: 环境参数
-      label:
-        en: 'Environmental parameters'
-        zh: '环境参数'
-        zh-Hant: '環境參數'
-        ja: '環境パラメータ'
-        ko: '환경 매개변수'
-        ru: 'Параметры среды'
-        ms: 'Parameter persekitaran'
-        pt-br: 'Parâmetros de ambiente'
       required: true
       type: text

--- a/apps/autoheal/latest/data.yml
+++ b/apps/autoheal/latest/data.yml
@@ -14,11 +14,5 @@ additionalProperties:
         ru: 'Параметры среды'
         ms: 'Parameter persekitaran'
         pt-br: 'Parâmetros de ambiente'
-        zh-Hant: '環境參數'
-        ja: '環境パラメータ'
-        ko: '환경 매개변수'
-        ru: 'Параметры среды'
-        ms: 'Parameter persekitaran'
-        pt-br: 'Parâmetros de ambiente'
       required: true
       type: text

--- a/apps/openclaw/2026.4.11-sandbox/data.yml
+++ b/apps/openclaw/2026.4.11-sandbox/data.yml
@@ -93,15 +93,6 @@ additionalProperties:
           value: "custom"
         - label: "auto"
           value: "auto"
-      label:
-        en: OpenClaw Gateway Bind
-        ja: OpenClaw ゲートウェイバインド
-        ms: Ikatan Gateway OpenClaw
-        pt-br: Vinculação do Gateway OpenClaw
-        ru: Привязка шлюза OpenClaw
-        ko: OpenClaw 게이트웨이 바인드
-        zh-Hant: OpenClaw 網關綁定
-        zh: OpenClaw 网关绑定
     - default: "local"
       disabled: true
       envKey: OPENCLAW_MODE

--- a/apps/openclaw/2026.4.11-sandbox/data.yml
+++ b/apps/openclaw/2026.4.11-sandbox/data.yml
@@ -71,15 +71,6 @@ additionalProperties:
       envKey: OPENCLAW_GATEWAY_BIND
       labelEn: OpenClaw Gateway Bind
       labelZh: OpenClaw 网关绑定
-      label:
-        en: 'OpenClaw Gateway Bind'
-        zh: 'OpenClaw 网关绑定'
-        zh-Hant: 'OpenClaw 網關綁定'
-        ja: 'OpenClaw ゲートウェイ バインド'
-        ko: 'OpenClaw 게이트웨이 바인드'
-        ru: 'Привязка шлюза OpenClaw'
-        ms: 'Pengikatan gerbang OpenClaw'
-        pt-br: 'Vinculação do gateway do OpenClaw'
       required: true
       type: select
       values:

--- a/apps/openclaw/2026.4.11/data.yml
+++ b/apps/openclaw/2026.4.11/data.yml
@@ -93,15 +93,6 @@ additionalProperties:
           value: "custom"
         - label: "auto"
           value: "auto"
-      label:
-        en: OpenClaw Gateway Bind
-        ja: OpenClaw ゲートウェイバインド
-        ms: Ikatan Gateway OpenClaw
-        pt-br: Vinculação do Gateway OpenClaw
-        ru: Привязка шлюза OpenClaw
-        ko: OpenClaw 게이트웨이 바인드
-        zh-Hant: OpenClaw 網關綁定
-        zh: OpenClaw 网关绑定
     - default: "local"
       disabled: true
       envKey: OPENCLAW_MODE

--- a/apps/openclaw/2026.4.11/data.yml
+++ b/apps/openclaw/2026.4.11/data.yml
@@ -71,15 +71,6 @@ additionalProperties:
       envKey: OPENCLAW_GATEWAY_BIND
       labelEn: OpenClaw Gateway Bind
       labelZh: OpenClaw 网关绑定
-      label:
-        en: 'OpenClaw Gateway Bind'
-        zh: 'OpenClaw 网关绑定'
-        zh-Hant: 'OpenClaw 網關綁定'
-        ja: 'OpenClaw ゲートウェイ バインド'
-        ko: 'OpenClaw 게이트웨이 바인드'
-        ru: 'Привязка шлюза OpenClaw'
-        ms: 'Pengikatan gerbang OpenClaw'
-        pt-br: 'Vinculação do gateway do OpenClaw'
       required: true
       type: select
       values:

--- a/apps/plex/official-latest/data.yml
+++ b/apps/plex/official-latest/data.yml
@@ -315,25 +315,9 @@ additionalProperties:
       type: select
       edit: true
       values:
-        - label:
-            en: 'True'
-            zh: '是'
-            zh-Hant: '是'
-            ja: 'はい'
-            ko: '예'
-            ru: 'Да'
-            ms: 'Ya'
-            pt-br: 'Sim'
+        - label: "True"
           value: "true"
-        - label:
-            en: 'False'
-            zh: '否'
-            zh-Hant: '否'
-            ja: 'いいえ'
-            ko: '아니요'
-            ru: 'Нет'
-            ms: 'Tidak'
-            pt-br: 'Não'
+        - label: "False"
           value: "false"
     - default: "192.168.1.0/24,172.18.0.0/16"
       edit: true

--- a/apps/plex/official-latest/data.yml
+++ b/apps/plex/official-latest/data.yml
@@ -5,15 +5,6 @@ additionalProperties:
       envKey: PANEL_APP_PORT_HTTP
       labelEn: Port 32400 (TCP)
       labelZh: 端口 32400 (TCP)
-      label:
-        en: 'Port 32400 (TCP)'
-        zh: '端口 32400 (TCP)'
-        zh-Hant: '埠 32400 (TCP)'
-        ja: 'ポート 32400 (TCP)'
-        ko: '포트 32400 (TCP)'
-        ru: 'Порт 32400 (TCP)'
-        ms: 'Port 32400 (TCP)'
-        pt-br: 'Porta 32400 (TCP)'
       required: true
       rule: paramPort
       type: number
@@ -22,15 +13,6 @@ additionalProperties:
       envKey: PANEL_APP_PORT_TCP_3005
       labelEn: Port 3005 (TCP)
       labelZh: 端口 3005 (TCP)
-      label:
-        en: 'Port 3005 (TCP)'
-        zh: '端口 3005 (TCP)'
-        zh-Hant: '埠 3005 (TCP)'
-        ja: 'ポート 3005 (TCP)'
-        ko: '포트 3005 (TCP)'
-        ru: 'Порт 3005 (TCP)'
-        ms: 'Port 3005 (TCP)'
-        pt-br: 'Porta 3005 (TCP)'
       required: true
       rule: paramPort
       type: number
@@ -39,15 +21,6 @@ additionalProperties:
       envKey: PANEL_APP_PORT_TCP_8324
       labelEn: Port 8324 (TCP)
       labelZh: 端口 8324 (TCP)
-      label:
-        en: 'Port 8324 (TCP)'
-        zh: '端口 8324 (TCP)'
-        zh-Hant: '埠 8324 (TCP)'
-        ja: 'ポート 8324 (TCP)'
-        ko: '포트 8324 (TCP)'
-        ru: 'Порт 8324 (TCP)'
-        ms: 'Port 8324 (TCP)'
-        pt-br: 'Porta 8324 (TCP)'
       required: true
       rule: paramPort
       type: number
@@ -56,15 +29,6 @@ additionalProperties:
       envKey: PANEL_APP_PORT_TCP_32469
       labelEn: Port 32469 (TCP)
       labelZh: 端口 32469 (TCP)
-      label:
-        en: 'Port 32469 (TCP)'
-        zh: '端口 32469 (TCP)'
-        zh-Hant: '埠 32469 (TCP)'
-        ja: 'ポート 32469 (TCP)'
-        ko: '포트 32469 (TCP)'
-        ru: 'Порт 32469 (TCP)'
-        ms: 'Port 32469 (TCP)'
-        pt-br: 'Porta 32469 (TCP)'
       required: true
       rule: paramPort
       type: number
@@ -73,15 +37,6 @@ additionalProperties:
       envKey: PANEL_APP_PORT_UDP_1900
       labelEn: Port 1900 (UDP)
       labelZh: 端口 1900 (UDP)
-      label:
-        en: 'Port 1900 (UDP)'
-        zh: '端口 1900 (UDP)'
-        zh-Hant: '埠 1900 (UDP)'
-        ja: 'ポート 1900 (UDP)'
-        ko: '포트 1900 (UDP)'
-        ru: 'Порт 1900 (UDP)'
-        ms: 'Port 1900 (UDP)'
-        pt-br: 'Porta 1900 (UDP)'
       required: true
       rule: paramPort
       type: number
@@ -90,15 +45,6 @@ additionalProperties:
       envKey: PANEL_APP_PORT_UDP_32410
       labelEn: Port 32410 (UDP)
       labelZh: 端口 32410 (UDP)
-      label:
-        en: 'Port 32410 (UDP)'
-        zh: '端口 32410 (UDP)'
-        zh-Hant: '埠 32410 (UDP)'
-        ja: 'ポート 32410 (UDP)'
-        ko: '포트 32410 (UDP)'
-        ru: 'Порт 32410 (UDP)'
-        ms: 'Port 32410 (UDP)'
-        pt-br: 'Porta 32410 (UDP)'
       required: true
       rule: paramPort
       type: number
@@ -107,15 +53,6 @@ additionalProperties:
       envKey: PANEL_APP_PORT_UDP_32412
       labelEn: Port 32412 (UDP)
       labelZh: 端口 32412 (UDP)
-      label:
-        en: 'Port 32412 (UDP)'
-        zh: '端口 32412 (UDP)'
-        zh-Hant: '埠 32412 (UDP)'
-        ja: 'ポート 32412 (UDP)'
-        ko: '포트 32412 (UDP)'
-        ru: 'Порт 32412 (UDP)'
-        ms: 'Port 32412 (UDP)'
-        pt-br: 'Porta 32412 (UDP)'
       required: true
       rule: paramPort
       type: number
@@ -124,15 +61,6 @@ additionalProperties:
       envKey: PANEL_APP_PORT_UDP_32413
       labelEn: Port 32413 (UDP)
       labelZh: 端口 32413 (UDP)
-      label:
-        en: 'Port 32413 (UDP)'
-        zh: '端口 32413 (UDP)'
-        zh-Hant: '埠 32413 (UDP)'
-        ja: 'ポート 32413 (UDP)'
-        ko: '포트 32413 (UDP)'
-        ru: 'Порт 32413 (UDP)'
-        ms: 'Port 32413 (UDP)'
-        pt-br: 'Porta 32413 (UDP)'
       required: true
       rule: paramPort
       type: number
@@ -141,15 +69,6 @@ additionalProperties:
       envKey: PANEL_APP_PORT_UDP_32414
       labelEn: Port 32414 (UDP)
       labelZh: 端口 32414 (UDP)
-      label:
-        en: 'Port 32414 (UDP)'
-        zh: '端口 32414 (UDP)'
-        zh-Hant: '埠 32414 (UDP)'
-        ja: 'ポート 32414 (UDP)'
-        ko: '포트 32414 (UDP)'
-        ru: 'Порт 32414 (UDP)'
-        ms: 'Port 32414 (UDP)'
-        pt-br: 'Porta 32414 (UDP)'
       required: true
       rule: paramPort
       type: number
@@ -158,15 +77,6 @@ additionalProperties:
       envKey: TIMEZONE
       labelEn: Timezone
       labelZh: 时区
-      label:
-        en: 'Timezone'
-        zh: '时区'
-        zh-Hant: '時區'
-        ja: 'タイムゾーン'
-        ko: '시간대'
-        ru: 'Часовой пояс'
-        ms: 'Zon waktu'
-        pt-br: 'Fuso horário'
       required: true
       type: text
     - default: ""
@@ -174,15 +84,6 @@ additionalProperties:
       envKey: CLAIM_TOKEN
       labelEn: Claim Token
       labelZh: 声明令牌
-      label:
-        en: 'Claim Token'
-        zh: '声明令牌'
-        zh-Hant: '聲明令牌'
-        ja: 'クレームトークン'
-        ko: '클레임 토큰'
-        ru: 'Claim токен'
-        ms: 'Token Claim'
-        pt-br: 'Token de claim'
       required: false
       type: text
     - default: "http://localhost:32400/"
@@ -190,15 +91,6 @@ additionalProperties:
       envKey: ADVERTISE_IP
       labelEn: External URL
       labelZh: 外部访问地址
-      label:
-        en: 'External URL'
-        zh: '外部访问地址'
-        zh-Hant: '外部訪問地址'
-        ja: '外部 URL'
-        ko: '외부 URL'
-        ru: 'Внешний URL'
-        ms: 'URL luaran'
-        pt-br: 'URL externa'
       required: true
       rule: paramExtUrl
       type: text
@@ -207,15 +99,6 @@ additionalProperties:
       envKey: HOSTNAME
       labelEn: Hostname
       labelZh: 主机名
-      label:
-        en: 'Hostname'
-        zh: '主机名'
-        zh-Hant: '主機名稱'
-        ja: 'ホスト名'
-        ko: '호스트명'
-        ru: 'Имя хоста'
-        ms: 'Nama hos'
-        pt-br: 'Nome do host'
       required: true
       type: text
     - default: "./data/plex/database"
@@ -223,15 +106,6 @@ additionalProperties:
       envKey: DATABASE_PATH
       labelEn: Database Path
       labelZh: 数据库路径
-      label:
-        en: 'Database Path'
-        zh: '数据库路径'
-        zh-Hant: '資料庫路徑'
-        ja: 'データベースパス'
-        ko: '데이터베이스 경로'
-        ru: 'Путь к базе данных'
-        ms: 'Laluan pangkalan data'
-        pt-br: 'Caminho do banco de dados'
       required: true
       type: text
     - default: "./data/transcode/temp"
@@ -239,15 +113,6 @@ additionalProperties:
       envKey: TRANSCODE_PATH
       labelEn: Transcode Path
       labelZh: 转码路径
-      label:
-        en: 'Transcode Path'
-        zh: '转码路径'
-        zh-Hant: '轉碼路徑'
-        ja: 'トランスコードパス'
-        ko: '트랜스코드 경로'
-        ru: 'Путь транскодирования'
-        ms: 'Laluan transkod'
-        pt-br: 'Caminho de transcodificação'
       required: true
       type: text
     - default: "./data/media"
@@ -255,15 +120,6 @@ additionalProperties:
       envKey: MEDIA_PATH
       labelEn: Media Path
       labelZh: 媒体路径
-      label:
-        en: 'Media Path'
-        zh: '媒体路径'
-        zh-Hant: '媒體路徑'
-        ja: 'メディアパス'
-        ko: '미디어 경로'
-        ru: 'Путь к медиа'
-        ms: 'Laluan media'
-        pt-br: 'Caminho de mídia'
       required: true
       type: text
     - default: ""
@@ -271,15 +127,6 @@ additionalProperties:
       envKey: PLEX_UID
       labelEn: Plex UID
       labelZh: Plex 用户 ID
-      label:
-        en: 'Plex UID'
-        zh: 'Plex 用户 ID'
-        zh-Hant: 'Plex 使用者 ID'
-        ja: 'Plex ユーザー ID'
-        ko: 'Plex 사용자 ID'
-        ru: 'ID пользователя Plex'
-        ms: 'ID pengguna Plex'
-        pt-br: 'ID do usuário Plex'
       required: false
       type: text
     - default: ""
@@ -287,30 +134,12 @@ additionalProperties:
       envKey: PLEX_GID
       labelEn: Plex GID
       labelZh: Plex 组 ID
-      label:
-        en: 'Plex GID'
-        zh: 'Plex 组 ID'
-        zh-Hant: 'Plex 群組 ID'
-        ja: 'Plex グループ ID'
-        ko: 'Plex 그룹 ID'
-        ru: 'ID группы Plex'
-        ms: 'ID kumpulan Plex'
-        pt-br: 'ID do grupo Plex'
       required: false
       type: text
     - default: "true"
       envKey: CHANGE_CONFIG_DIR_OWNERSHIP
       labelEn: Change Config Dir Ownership
       labelZh: 更改配置目录所有权
-      label:
-        en: 'Change Config Dir Ownership'
-        zh: '更改配置目录所有权'
-        zh-Hant: '變更配置目錄所有權'
-        ja: '設定ディレクトリ所有権を変更'
-        ko: '설정 디렉터리 소유권 변경'
-        ru: 'Изменить владельца каталога конфигурации'
-        ms: 'Ubah pemilikan direktori konfigurasi'
-        pt-br: 'Alterar propriedade do diretório de configuração'
       required: true
       type: select
       edit: true
@@ -324,14 +153,5 @@ additionalProperties:
       envKey: ALLOWED_NETWORKS
       labelEn: Allowed Networks
       labelZh: 允许的网络
-      label:
-        en: 'Allowed Networks'
-        zh: '允许的网络'
-        zh-Hant: '允許的網路'
-        ja: '許可されたネットワーク'
-        ko: '허용된 네트워크'
-        ru: 'Разрешенные сети'
-        ms: 'Rangkaian yang dibenarkan'
-        pt-br: 'Redes permitidas'
       required: false
       type: text

--- a/apps/radarr/6.0.4/data.yml
+++ b/apps/radarr/6.0.4/data.yml
@@ -79,15 +79,6 @@ additionalProperties:
         ru: 'Путь к конфигурации Radarr'
         ms: 'Laluan konfigurasi Radarr'
         pt-br: 'Caminho de configuração do Radarr'
-      label:
-        en: 'Radarr Config Path'
-        zh: 'Radarr 配置路径'
-        zh-Hant: 'Radarr 配置路徑'
-        ja: 'Radarr 設定パス'
-        ko: 'Radarr 구성 경로'
-        ru: 'Путь к конфигурации Radarr'
-        ms: 'Laluan konfigurasi Radarr'
-        pt-br: 'Caminho de configuração do Radarr'
       required: true
       type: text
     - default: "./data/movies"
@@ -104,15 +95,6 @@ additionalProperties:
         ru: 'Путь к фильмам'
         ms: 'Laluan filem'
         pt-br: 'Caminho de filmes'
-      label:
-        en: 'Movies Path'
-        zh: '电影路径'
-        zh-Hant: '電影路徑'
-        ja: '映画パス'
-        ko: '영화 경로'
-        ru: 'Путь к фильмам'
-        ms: 'Laluan filem'
-        pt-br: 'Caminho dos filmes'
       required: true
       type: text
     - default: "./data/downloads"

--- a/apps/radarr/6.0.4/data.yml
+++ b/apps/radarr/6.0.4/data.yml
@@ -5,15 +5,6 @@ additionalProperties:
       envKey: PANEL_APP_PORT_HTTP
       labelEn: Port
       labelZh: 端口
-      label:
-        en: 'Port'
-        zh: '端口'
-        zh-Hant: '埠'
-        ja: 'ポート'
-        ko: '포트'
-        ru: 'Порт'
-        ms: 'Port'
-        pt-br: 'Porta'
       required: true
       rule: paramPort
       type: number
@@ -22,15 +13,6 @@ additionalProperties:
       envKey: PUID
       labelEn: User ID
       labelZh: 用户 ID
-      label:
-        en: 'User ID'
-        zh: '用户 ID'
-        zh-Hant: '使用者 ID'
-        ja: 'ユーザー ID'
-        ko: '사용자 ID'
-        ru: 'ID пользователя'
-        ms: 'ID pengguna'
-        pt-br: 'ID do usuário'
       required: true
       type: number
     - default: "1000"
@@ -38,15 +20,6 @@ additionalProperties:
       envKey: PGID
       labelEn: Group ID
       labelZh: 组 ID
-      label:
-        en: 'Group ID'
-        zh: '组 ID'
-        zh-Hant: '群組 ID'
-        ja: 'グループ ID'
-        ko: '그룹 ID'
-        ru: 'ID группы'
-        ms: 'ID kumpulan'
-        pt-br: 'ID do grupo'
       required: true
       type: number
     - default: "Asia/Shanghai"
@@ -54,15 +27,6 @@ additionalProperties:
       envKey: TIME_ZONE
       labelEn: Time Zone
       labelZh: 时区
-      label:
-        en: 'Time Zone'
-        zh: '时区'
-        zh-Hant: '時區'
-        ja: 'タイムゾーン'
-        ko: '시간대'
-        ru: 'Часовой пояс'
-        ms: 'Zon masa'
-        pt-br: 'Fuso horário'
       required: true
       type: text
     - default: "./data/data"
@@ -70,15 +34,6 @@ additionalProperties:
       envKey: RADARR_CONFIG_PATH
       labelEn: Radarr Config Path
       labelZh: Radarr 配置路径
-      label:
-        en: 'Radarr Config Path'
-        zh: 'Radarr 配置路径'
-        zh-Hant: 'Radarr 設定路徑'
-        ja: 'Radarr 設定パス'
-        ko: 'Radarr 구성 경로'
-        ru: 'Путь к конфигурации Radarr'
-        ms: 'Laluan konfigurasi Radarr'
-        pt-br: 'Caminho de configuração do Radarr'
       required: true
       type: text
     - default: "./data/movies"
@@ -86,15 +41,6 @@ additionalProperties:
       envKey: MOVIES_PATH
       labelEn: Movies Path
       labelZh: 电影路径
-      label:
-        en: 'Movies Path'
-        zh: '电影路径'
-        zh-Hant: '電影路徑'
-        ja: '映画パス'
-        ko: '영화 경로'
-        ru: 'Путь к фильмам'
-        ms: 'Laluan filem'
-        pt-br: 'Caminho de filmes'
       required: true
       type: text
     - default: "./data/downloads"
@@ -102,14 +48,5 @@ additionalProperties:
       envKey: DOWNLOADS_PATH
       labelEn: Downloads Path
       labelZh: 下载路径
-      label:
-        en: 'Downloads Path'
-        zh: '下载路径'
-        zh-Hant: '下載路徑'
-        ja: 'ダウンロードパス'
-        ko: '다운로드 경로'
-        ru: 'Путь к загрузкам'
-        ms: 'Laluan muat turun'
-        pt-br: 'Caminho de downloads'
       required: true
       type: text

--- a/apps/sonarr/4.0.17/data.yml
+++ b/apps/sonarr/4.0.17/data.yml
@@ -5,15 +5,6 @@ additionalProperties:
       envKey: PANEL_APP_PORT_HTTP
       labelEn: Port
       labelZh: 端口
-      label:
-        en: 'Port'
-        zh: '端口'
-        zh-Hant: '埠'
-        ja: 'ポート'
-        ko: '포트'
-        ru: 'Порт'
-        ms: 'Port'
-        pt-br: 'Porta'
       required: true
       rule: paramPort
       type: number
@@ -22,15 +13,6 @@ additionalProperties:
       envKey: PUID
       labelEn: User ID
       labelZh: 用户 ID
-      label:
-        en: 'User ID'
-        zh: '用户 ID'
-        zh-Hant: '使用者 ID'
-        ja: 'ユーザー ID'
-        ko: '사용자 ID'
-        ru: 'ID пользователя'
-        ms: 'ID pengguna'
-        pt-br: 'ID do usuário'
       required: true
       type: number
     - default: "1000"
@@ -38,15 +20,6 @@ additionalProperties:
       envKey: PGID
       labelEn: Group ID
       labelZh: 组 ID
-      label:
-        en: 'Group ID'
-        zh: '组 ID'
-        zh-Hant: '群組 ID'
-        ja: 'グループ ID'
-        ko: '그룹 ID'
-        ru: 'ID группы'
-        ms: 'ID kumpulan'
-        pt-br: 'ID do grupo'
       required: true
       type: number
     - default: "Asia/Shanghai"
@@ -54,15 +27,6 @@ additionalProperties:
       envKey: TIME_ZONE
       labelEn: Time Zone
       labelZh: 时区
-      label:
-        en: 'Time Zone'
-        zh: '时区'
-        zh-Hant: '時區'
-        ja: 'タイムゾーン'
-        ko: '시간대'
-        ru: 'Часовой пояс'
-        ms: 'Zon masa'
-        pt-br: 'Fuso horário'
       required: true
       type: text
     - default: "./data/config"
@@ -70,15 +34,6 @@ additionalProperties:
       envKey: SONARR_CONFIG_PATH
       labelEn: Sonarr Config Path
       labelZh: Sonarr 配置路径
-      label:
-        en: 'Sonarr Config Path'
-        zh: 'Sonarr 配置路径'
-        zh-Hant: 'Sonarr 設定路徑'
-        ja: 'Sonarr 設定パス'
-        ko: 'Sonarr 구성 경로'
-        ru: 'Путь к конфигурации Sonarr'
-        ms: 'Laluan konfigurasi Sonarr'
-        pt-br: 'Caminho de configuração do Sonarr'
       required: true
       type: text
     - default: "./data/tv"
@@ -86,15 +41,6 @@ additionalProperties:
       envKey: TV_SERIES_PATH
       labelEn: TV Series Path
       labelZh: 电视剧路径
-      label:
-        en: 'TV Series Path'
-        zh: '电视剧路径'
-        zh-Hant: '電視劇路徑'
-        ja: 'テレビシリーズパス'
-        ko: 'TV 시리즈 경로'
-        ru: 'Путь к сериалам'
-        ms: 'Laluan siri TV'
-        pt-br: 'Caminho das séries de TV'
       required: true
       type: text
     - default: "./data/downloads"
@@ -102,14 +48,5 @@ additionalProperties:
       envKey: DOWNLOADS_PATH
       labelEn: Downloads Path
       labelZh: 下载路径
-      label:
-        en: 'Downloads Path'
-        zh: '下载路径'
-        zh-Hant: '下載路徑'
-        ja: 'ダウンロードパス'
-        ko: '다운로드 경로'
-        ru: 'Путь к загрузкам'
-        ms: 'Laluan muat turun'
-        pt-br: 'Caminho de downloads'
       required: true
       type: text

--- a/apps/sonarr/4.0.17/data.yml
+++ b/apps/sonarr/4.0.17/data.yml
@@ -79,15 +79,6 @@ additionalProperties:
         ru: 'Путь к конфигурации Sonarr'
         ms: 'Laluan konfigurasi Sonarr'
         pt-br: 'Caminho de configuração do Sonarr'
-      label:
-        en: 'Sonarr Config Path'
-        zh: 'Sonarr 配置路径'
-        zh-Hant: 'Sonarr 配置路徑'
-        ja: 'Sonarr 設定パス'
-        ko: 'Sonarr 구성 경로'
-        ru: 'Путь к конфигурации Sonarr'
-        ms: 'Laluan konfigurasi Sonarr'
-        pt-br: 'Caminho de configuração do Sonarr'
       required: true
       type: text
     - default: "./data/tv"
@@ -95,15 +86,6 @@ additionalProperties:
       envKey: TV_SERIES_PATH
       labelEn: TV Series Path
       labelZh: 电视剧路径
-      label:
-        en: 'TV Series Path'
-        zh: '电视剧路径'
-        zh-Hant: '電視劇路徑'
-        ja: 'テレビシリーズパス'
-        ko: 'TV 시리즈 경로'
-        ru: 'Путь к сериалам'
-        ms: 'Laluan siri TV'
-        pt-br: 'Caminho das séries de TV'
       label:
         en: 'TV Series Path'
         zh: '电视剧路径'

--- a/apps/sonarr/latest/data.yml
+++ b/apps/sonarr/latest/data.yml
@@ -5,15 +5,6 @@ additionalProperties:
       envKey: PANEL_APP_PORT_HTTP
       labelEn: Port
       labelZh: 端口
-      label:
-        en: 'Port'
-        zh: '端口'
-        zh-Hant: '埠'
-        ja: 'ポート'
-        ko: '포트'
-        ru: 'Порт'
-        ms: 'Port'
-        pt-br: 'Porta'
       required: true
       rule: paramPort
       type: number
@@ -22,15 +13,6 @@ additionalProperties:
       envKey: PUID
       labelEn: User ID
       labelZh: 用户 ID
-      label:
-        en: 'User ID'
-        zh: '用户 ID'
-        zh-Hant: '使用者 ID'
-        ja: 'ユーザー ID'
-        ko: '사용자 ID'
-        ru: 'ID пользователя'
-        ms: 'ID pengguna'
-        pt-br: 'ID do usuário'
       required: true
       type: number
     - default: "1000"
@@ -38,15 +20,6 @@ additionalProperties:
       envKey: PGID
       labelEn: Group ID
       labelZh: 组 ID
-      label:
-        en: 'Group ID'
-        zh: '组 ID'
-        zh-Hant: '群組 ID'
-        ja: 'グループ ID'
-        ko: '그룹 ID'
-        ru: 'ID группы'
-        ms: 'ID kumpulan'
-        pt-br: 'ID do grupo'
       required: true
       type: number
     - default: "Asia/Shanghai"
@@ -54,15 +27,6 @@ additionalProperties:
       envKey: TIME_ZONE
       labelEn: Time Zone
       labelZh: 时区
-      label:
-        en: 'Time Zone'
-        zh: '时区'
-        zh-Hant: '時區'
-        ja: 'タイムゾーン'
-        ko: '시간대'
-        ru: 'Часовой пояс'
-        ms: 'Zon masa'
-        pt-br: 'Fuso horário'
       required: true
       type: text
     - default: "./data/config"
@@ -70,15 +34,6 @@ additionalProperties:
       envKey: SONARR_CONFIG_PATH
       labelEn: Sonarr Config Path
       labelZh: Sonarr 配置路径
-      label:
-        en: 'Sonarr Config Path'
-        zh: 'Sonarr 配置路径'
-        zh-Hant: 'Sonarr 設定路徑'
-        ja: 'Sonarr 設定パス'
-        ko: 'Sonarr 구성 경로'
-        ru: 'Путь к конфигурации Sonarr'
-        ms: 'Laluan konfigurasi Sonarr'
-        pt-br: 'Caminho de configuração do Sonarr'
       required: true
       type: text
     - default: "./data/tv"
@@ -86,15 +41,6 @@ additionalProperties:
       envKey: TV_SERIES_PATH
       labelEn: TV Series Path
       labelZh: 电视剧路径
-      label:
-        en: 'TV Series Path'
-        zh: '电视剧路径'
-        zh-Hant: '電視劇路徑'
-        ja: 'テレビシリーズパス'
-        ko: 'TV 시리즈 경로'
-        ru: 'Путь к сериалам'
-        ms: 'Laluan siri TV'
-        pt-br: 'Caminho das séries de TV'
       required: true
       type: text
     - default: "./data/downloads"
@@ -102,14 +48,5 @@ additionalProperties:
       envKey: DOWNLOADS_PATH
       labelEn: Downloads Path
       labelZh: 下载路径
-      label:
-        en: 'Downloads Path'
-        zh: '下载路径'
-        zh-Hant: '下載路徑'
-        ja: 'ダウンロードパス'
-        ko: '다운로드 경로'
-        ru: 'Путь к загрузкам'
-        ms: 'Laluan muat turun'
-        pt-br: 'Caminho de downloads'
       required: true
       type: text

--- a/apps/wewe-rss/latest-mysql/data.yml
+++ b/apps/wewe-rss/latest-mysql/data.yml
@@ -21,25 +21,9 @@ additionalProperties:
       required: true
       type: apps
       values:
-        - label:
-            en: 'MySQL'
-            zh: 'MySQL'
-            zh-Hant: 'MySQL'
-            ja: 'MySQL'
-            ko: 'MySQL'
-            ru: 'MySQL'
-            ms: 'MySQL'
-            pt-br: 'MySQL'
+        - label: "MySQL"
           value: mysql
-        - label:
-            en: 'LocalMySQL'
-            zh: 'LocalMySQL'
-            zh-Hant: 'LocalMySQL'
-            ja: 'LocalMySQL'
-            ko: 'LocalMySQL'
-            ru: 'LocalMySQL'
-            ms: 'LocalMySQL'
-            pt-br: 'LocalMySQL'
+        - label: "LocalMySQL"
           value: localmysql
     - default: "wewe-rss"
       envKey: PANEL_DB_NAME

--- a/apps/wewe-rss/latest-mysql/data.yml
+++ b/apps/wewe-rss/latest-mysql/data.yml
@@ -9,15 +9,6 @@ additionalProperties:
       envKey: PANEL_DB_TYPE
       labelEn: Database Service
       labelZh: 数据库服务
-      label:
-        en: 'Database Service'
-        zh: '数据库服务'
-        zh-Hant: '數據庫服務'
-        ja: 'データベースサービス'
-        ko: '데이터베이스 서비스'
-        ru: 'Сервис базы данных'
-        ms: 'Perkhidmatan Pangkalan Data'
-        pt-br: 'Serviço de Banco de Dados'
       required: true
       type: apps
       values:
@@ -29,15 +20,6 @@ additionalProperties:
       envKey: PANEL_DB_NAME
       labelEn: Database
       labelZh: 数据库名
-      label:
-        en: 'Database'
-        zh: '数据库名'
-        zh-Hant: '數據庫名'
-        ja: 'データベース'
-        ko: '데이터베이스'
-        ru: 'База данных'
-        ms: 'Pangkalan Data'
-        pt-br: 'Banco de Dados'
       random: true
       required: true
       rule: paramCommon
@@ -46,15 +28,6 @@ additionalProperties:
       envKey: PANEL_DB_USER
       labelEn: User
       labelZh: 数据库用户
-      label:
-        en: 'User'
-        zh: '数据库用户'
-        zh-Hant: '數據庫用戶'
-        ja: 'ユーザー'
-        ko: '사용자'
-        ru: 'Пользователь'
-        ms: 'Pengguna'
-        pt-br: 'Usuário'
       random: true
       required: true
       rule: paramCommon
@@ -63,15 +36,6 @@ additionalProperties:
       envKey: PANEL_DB_USER_PASSWORD
       labelEn: Password
       labelZh: 数据库用户密码
-      label:
-        en: 'Password'
-        zh: '数据库用户密码'
-        zh-Hant: '數據庫用戶密碼'
-        ja: 'パスワード'
-        ko: '비밀번호'
-        ru: 'Пароль'
-        ms: 'Kata laluan'
-        pt-br: 'Senha'
       random: true
       required: true
       rule: paramComplexity
@@ -81,15 +45,6 @@ additionalProperties:
       envKey: PANEL_APP_PORT_HTTP
       labelEn: Port
       labelZh: 端口
-      label:
-        en: 'Port'
-        zh: '端口'
-        zh-Hant: '埠'
-        ja: 'ポート'
-        ko: '포트'
-        ru: 'Порт'
-        ms: 'Port'
-        pt-br: 'Porta'
       required: true
       rule: paramPort
       type: number
@@ -98,15 +53,6 @@ additionalProperties:
       envKey: AUTH_CODE
       labelEn: Auth Code
       labelZh: 授权码
-      label:
-        en: 'Auth Code'
-        zh: '授权码'
-        zh-Hant: '授權碼'
-        ja: '認証コード'
-        ko: '인증 코드'
-        ru: 'Код авторизации'
-        ms: 'Kod pengesahan'
-        pt-br: 'Código de autenticação'
       random: true
       required: true
       rule: paramComplexity
@@ -116,15 +62,6 @@ additionalProperties:
       envKey: SERVER_ORIGIN_URL
       labelEn: External URL
       labelZh: 外部访问地址
-      label:
-        en: 'External URL'
-        zh: '外部访问地址'
-        zh-Hant: '外部訪問地址'
-        ja: '外部 URL'
-        ko: '외부 URL'
-        ru: 'Внешний URL'
-        ms: 'URL luaran'
-        pt-br: 'URL externa'
       required: true
       rule: paramExtUrl
       type: text
@@ -133,15 +70,6 @@ additionalProperties:
       envKey: FEED_MODE
       labelEn: Feed Mode
       labelZh: 提取模式
-      label:
-        en: 'Feed Mode'
-        zh: '提取模式'
-        zh-Hant: '擷取模式'
-        ja: 'フィードモード'
-        ko: '피드 모드'
-        ru: 'Режим ленты'
-        ms: 'Mod suapan'
-        pt-br: 'Modo de feed'
       required: false
       type: text
     - default: "35 5,17 * * *"
@@ -149,15 +77,6 @@ additionalProperties:
       envKey: CRON_EXPRESSION
       labelEn: Cron Expression
       labelZh: 定时更新表达式
-      label:
-        en: 'Cron Expression'
-        zh: '定时更新表达式'
-        zh-Hant: '定時更新表達式'
-        ja: 'Cron 式'
-        ko: '크론 표현식'
-        ru: 'Выражение cron'
-        ms: 'Ungkapan cron'
-        pt-br: 'Expressão cron'
       required: false
       type: text
     - default: "60"
@@ -165,14 +84,5 @@ additionalProperties:
       envKey: MAX_REQUEST_PER_MINUTE
       labelEn: Max Requests Per Minute
       labelZh: 每分钟最大请求次数
-      label:
-        en: 'Max Requests Per Minute'
-        zh: '每分钟最大请求次数'
-        zh-Hant: '每分鐘最大請求次數'
-        ja: '1 分あたりの最大リクエスト数'
-        ko: '분당 최대 요청 수'
-        ru: 'Максимум запросов в минуту'
-        ms: 'Maksimum permintaan per minit'
-        pt-br: 'Máximo de solicitações por minuto'
       required: false
       type: number

--- a/apps/woodpecker/3.13.0/data.yml
+++ b/apps/woodpecker/3.13.0/data.yml
@@ -5,15 +5,6 @@ additionalProperties:
       envKey: PANEL_APP_PORT_HTTP
       labelEn: Port
       labelZh: 端口
-      label:
-        en: 'Port'
-        zh: '端口'
-        zh-Hant: '埠'
-        ja: 'ポート'
-        ko: '포트'
-        ru: 'Порт'
-        ms: 'Port'
-        pt-br: 'Porta'
       required: true
       rule: paramPort
       type: number
@@ -22,15 +13,6 @@ additionalProperties:
       envKey: DATA_PATH
       labelEn: Data folder path
       labelZh: 数据文件夹路径
-      label:
-        en: 'Data folder path'
-        zh: '数据文件夹路径'
-        zh-Hant: '資料夾路徑'
-        ja: 'データフォルダパス'
-        ko: '데이터 폴더 경로'
-        ru: 'Путь к папке данных'
-        ms: 'Laluan folder data'
-        pt-br: 'Caminho da pasta de dados'
       required: true
       type: text
     - default: "false"
@@ -38,15 +20,6 @@ additionalProperties:
       envKey: REGISTER_SWITCH
       labelEn: Enable register (true or false)
       labelZh: 启用注册(true/false)
-      label:
-        en: 'Enable register (true or false)'
-        zh: '启用注册(true/false)'
-        zh-Hant: '啟用註冊(true/false)'
-        ja: '登録を有効化（true/false）'
-        ko: '등록 활성화(true/false)'
-        ru: 'Включить регистрацию (true/false)'
-        ms: 'Dayakan pendaftaran (true/false)'
-        pt-br: 'Ativar registro (true/false)'
       required: true
       type: text
     - default: http://ci.example.com
@@ -54,15 +27,6 @@ additionalProperties:
       envKey: WOODPECKER_HOST
       labelEn: External URL
       labelZh: 外部访问地址
-      label:
-        en: 'External URL'
-        zh: '外部访问地址'
-        zh-Hant: '外部訪問地址'
-        ja: '外部 URL'
-        ko: '외부 URL'
-        ru: 'Внешний URL'
-        ms: 'URL luaran'
-        pt-br: 'URL externa'
       required: true
       type: text
     - default: ''
@@ -70,15 +34,6 @@ additionalProperties:
       envKey: WOODPECKER_AGENT_SECRET
       labelEn: Github Agent Secret Vaule
       labelZh: Github Agent Secret 值
-      label:
-        en: 'Github Agent Secret Vaule'
-        zh: 'Github Agent Secret 值'
-        zh-Hant: 'Github Agent Secret 值'
-        ja: 'Github Agent Secret 値'
-        ko: 'Github Agent Secret 값'
-        ru: 'Значение Github Agent Secret'
-        ms: 'Nilai Github Agent Secret'
-        pt-br: 'Valor do Github Agent Secret'
       required: true
       type: text
     - default: "true"
@@ -86,15 +41,6 @@ additionalProperties:
       envKey: GITHUB_ENABLE_SWITCH
       labelEn: Enable Github (true or false)
       labelZh: 启用Github(true/false)
-      label:
-        en: 'Enable Github (true or false)'
-        zh: '启用Github(true/false)'
-        zh-Hant: '啟用Github(true/false)'
-        ja: 'Github を有効化（true/false）'
-        ko: 'Github 활성화(true/false)'
-        ru: 'Включить Github (true/false)'
-        ms: 'Dayakan Github (true/false)'
-        pt-br: 'Ativar Github (true/false)'
       required: true
       type: text
     - default: https://github.com
@@ -102,15 +48,6 @@ additionalProperties:
       envKey: WOODPECKER_GITHUB_URL
       labelEn: Github URL
       labelZh: Github地址
-      label:
-        en: 'Github URL'
-        zh: 'Github地址'
-        zh-Hant: 'Github 地址'
-        ja: 'Github の URL'
-        ko: 'Github URL 주소'
-        ru: 'URL Github'
-        ms: 'URL Github'
-        pt-br: 'URL do Github'
       required: false
       type: text
     - default: ''
@@ -118,15 +55,6 @@ additionalProperties:
       envKey: WOODPECKER_GITHUB_CLIENT
       labelEn: Github CLIENT Vaule
       labelZh: Github CLIENT 值
-      label:
-        en: 'Github CLIENT Vaule'
-        zh: 'Github CLIENT 值'
-        zh-Hant: 'Github CLIENT 值'
-        ja: 'Github CLIENT 値'
-        ko: 'Github CLIENT 값'
-        ru: 'Значение Github CLIENT'
-        ms: 'Nilai Github CLIENT'
-        pt-br: 'Valor do Github CLIENT'
       required: false
       type: text
     - default: ''
@@ -134,15 +62,6 @@ additionalProperties:
       envKey: WOODPECKER_GITHUB_SECRET
       labelEn: Github SECRET Vaule
       labelZh: Github SECRET 值
-      label:
-        en: 'Github SECRET Vaule'
-        zh: 'Github SECRET 值'
-        zh-Hant: 'Github SECRET 值'
-        ja: 'Github SECRET 値'
-        ko: 'Github SECRET 값'
-        ru: 'Значение Github SECRET'
-        ms: 'Nilai Github SECRET'
-        pt-br: 'Valor do Github SECRET'
       required: false
       type: text
     - default: "false"
@@ -150,15 +69,6 @@ additionalProperties:
       envKey: GITEA_ENABLE_SWITCH
       labelEn: Enable Gitea (true or false)
       labelZh: 启用Gitea(true/false)
-      label:
-        en: 'Enable Gitea (true or false)'
-        zh: '启用Gitea(true/false)'
-        zh-Hant: '啟用Gitea(true/false)'
-        ja: 'Gitea を有効化（true/false）'
-        ko: 'Gitea 활성화(true/false)'
-        ru: 'Включить Gitea (true/false)'
-        ms: 'Dayakan Gitea (true/false)'
-        pt-br: 'Ativar Gitea (true/false)'
       required: true
       type: text
     - default: https://try.gitea.io
@@ -166,15 +76,6 @@ additionalProperties:
       envKey: WOODPECKER_GITEA_URL
       labelEn: Gitea URL
       labelZh: Gitea地址
-      label:
-        en: 'Gitea URL'
-        zh: 'Gitea地址'
-        zh-Hant: 'Gitea 地址'
-        ja: 'Gitea の URL'
-        ko: 'Gitea URL 주소'
-        ru: 'URL Gitea'
-        ms: 'URL Gitea'
-        pt-br: 'URL do Gitea'
       required: false
       type: text
     - default: ''
@@ -182,15 +83,6 @@ additionalProperties:
       envKey: WOODPECKER_GITEA_CLIENT
       labelEn: Gitea CLIENT Vaule
       labelZh: Gitea CLIENT 值
-      label:
-        en: 'Gitea CLIENT Vaule'
-        zh: 'Gitea CLIENT 值'
-        zh-Hant: 'Gitea CLIENT 值'
-        ja: 'Gitea CLIENT 値'
-        ko: 'Gitea CLIENT 값'
-        ru: 'Значение Gitea CLIENT'
-        ms: 'Nilai Gitea CLIENT'
-        pt-br: 'Valor do Gitea CLIENT'
       required: false
       type: text
     - default: ''
@@ -198,15 +90,6 @@ additionalProperties:
       envKey: WOODPECKER_GITEA_SECRET
       labelEn: Gitea SECRET Vaule
       labelZh: Gitea SECRET 值
-      label:
-        en: 'Gitea SECRET Vaule'
-        zh: 'Gitea SECRET 值'
-        zh-Hant: 'Gitea SECRET 值'
-        ja: 'Gitea SECRET 値'
-        ko: 'Gitea SECRET 값'
-        ru: 'Значение Gitea SECRET'
-        ms: 'Nilai Gitea SECRET'
-        pt-br: 'Valor do Gitea SECRET'
       required: false
       type: text
     - default: "false"
@@ -214,15 +97,6 @@ additionalProperties:
       envKey: GITLAB_ENABLE_SWITCH
       labelEn: Enable GitLab (true or false)
       labelZh: 启用GitLab (true/false)
-      label:
-        en: 'Enable GitLab (true or false)'
-        zh: '启用GitLab (true/false)'
-        zh-Hant: '啟用GitLab (true/false)'
-        ja: 'GitLab を有効化（true/false）'
-        ko: 'GitLab 활성화(true/false)'
-        ru: 'Включить GitLab (true/false)'
-        ms: 'Dayakan GitLab (true/false)'
-        pt-br: 'Ativar GitLab (true/false)'
       required: true
       type: text
     - default: https://gitlab.com
@@ -230,15 +104,6 @@ additionalProperties:
       envKey: WOODPECKER_GITLAB_URL
       labelEn: GitLab URL
       labelZh: GitLab 地址
-      label:
-        en: 'GitLab URL'
-        zh: 'GitLab 地址'
-        zh-Hant: 'GitLab 地址'
-        ja: 'GitLab の URL'
-        ko: 'GitLab URL 주소'
-        ru: 'URL GitLab'
-        ms: 'URL GitLab'
-        pt-br: 'URL do GitLab'
       required: false
       type: text
     - default: ''
@@ -246,15 +111,6 @@ additionalProperties:
       envKey: WOODPECKER_GITLAB_CLIENT
       labelEn: GitLab CLIENT Vaule
       labelZh: GitLab CLIENT 值
-      label:
-        en: 'GitLab CLIENT Vaule'
-        zh: 'GitLab CLIENT 值'
-        zh-Hant: 'GitLab CLIENT 值'
-        ja: 'GitLab CLIENT 値'
-        ko: 'GitLab CLIENT 값'
-        ru: 'Значение GitLab CLIENT'
-        ms: 'Nilai GitLab CLIENT'
-        pt-br: 'Valor do GitLab CLIENT'
       required: false
       type: text
     - default: ''
@@ -262,15 +118,6 @@ additionalProperties:
       envKey: WOODPECKER_GITLAB_SECRET
       labelEn: GitLab SECRET Vaule
       labelZh: GitLab SECRET 值
-      label:
-        en: 'GitLab SECRET Vaule'
-        zh: 'GitLab SECRET 值'
-        zh-Hant: 'GitLab SECRET 值'
-        ja: 'GitLab SECRET 値'
-        ko: 'GitLab SECRET 값'
-        ru: 'Значение GitLab SECRET'
-        ms: 'Nilai GitLab SECRET'
-        pt-br: 'Valor do GitLab SECRET'
       required: false
       type: text
     - default: "false"
@@ -278,15 +125,6 @@ additionalProperties:
       envKey: BITBUCKET_ENABLE_SWITCH
       labelEn: Enable Bitbucket (true or false)
       labelZh: 启用 Bitbucket (true/false)
-      label:
-        en: 'Enable Bitbucket (true or false)'
-        zh: '启用 Bitbucket (true/false)'
-        zh-Hant: '啟用 Bitbucket (true/false)'
-        ja: 'Bitbucket を有効化（true/false）'
-        ko: 'Bitbucket 활성화(true/false)'
-        ru: 'Включить Bitbucket (true/false)'
-        ms: 'Dayakan Bitbucket (true/false)'
-        pt-br: 'Ativar Bitbucket (true/false)'
       required: true
       type: text
     - default: ''
@@ -294,15 +132,6 @@ additionalProperties:
       envKey: WOODPECKER_BITBUCKET_CLIENT
       labelEn: Bitbucket CLIENT Value
       labelZh: Bitbucket CLIENT 值
-      label:
-        en: 'Bitbucket CLIENT Value'
-        zh: 'Bitbucket CLIENT 值'
-        zh-Hant: 'Bitbucket CLIENT 值'
-        ja: 'Bitbucket CLIENT 値'
-        ko: 'Bitbucket CLIENT 값'
-        ru: 'Значение Bitbucket CLIENT'
-        ms: 'Nilai Bitbucket CLIENT'
-        pt-br: 'Valor do Bitbucket CLIENT'
       required: false
       type: text
     - default: ''
@@ -310,14 +139,5 @@ additionalProperties:
       envKey: WOODPECKER_BITBUCKET_SECRET
       labelEn: Bitbucket SECRET Value
       labelZh: Bitbucket SECRET 值
-      label:
-        en: 'Bitbucket SECRET Value'
-        zh: 'Bitbucket SECRET 值'
-        zh-Hant: 'Bitbucket SECRET 值'
-        ja: 'Bitbucket SECRET 値'
-        ko: 'Bitbucket SECRET 값'
-        ru: 'Значение Bitbucket SECRET'
-        ms: 'Nilai Bitbucket SECRET'
-        pt-br: 'Valor do Bitbucket SECRET'
       required: false
       type: text

--- a/apps/woodpecker/3.13.0/data.yml
+++ b/apps/woodpecker/3.13.0/data.yml
@@ -79,15 +79,6 @@ additionalProperties:
         ru: 'Значение Github Agent Secret'
         ms: 'Nilai Github Agent Secret'
         pt-br: 'Valor do Github Agent Secret'
-      label:
-        en: 'Github Agent Secret Vaule'
-        zh: 'Github Agent Secret 值'
-        zh-Hant: 'Github Agent Secret 值'
-        ja: 'Github Agent Secret 値'
-        ko: 'Github Agent Secret 값'
-        ru: 'Значение Github Agent Secret'
-        ms: 'Nilai Github Agent Secret'
-        pt-br: 'Valor do Github Agent Secret'
       required: true
       type: text
     - default: "true"
@@ -95,15 +86,6 @@ additionalProperties:
       envKey: GITHUB_ENABLE_SWITCH
       labelEn: Enable Github (true or false)
       labelZh: 启用Github(true/false)
-      label:
-        en: 'Enable Github (true or false)'
-        zh: '启用Github(true/false)'
-        zh-Hant: '啟用Github(true/false)'
-        ja: 'Github を有効化（true/false）'
-        ko: 'Github 활성화(true/false)'
-        ru: 'Включить Github (true/false)'
-        ms: 'Dayakan Github (true/false)'
-        pt-br: 'Ativar Github (true/false)'
       label:
         en: 'Enable Github (true or false)'
         zh: '启用Github(true/false)'
@@ -129,15 +111,6 @@ additionalProperties:
         ru: 'URL Github'
         ms: 'URL Github'
         pt-br: 'URL do Github'
-      label:
-        en: 'Github URL'
-        zh: 'Github地址'
-        zh-Hant: 'Github 地址'
-        ja: 'Github の URL'
-        ko: 'Github URL 주소'
-        ru: 'URL Github'
-        ms: 'URL Github'
-        pt-br: 'URL do Github'
       required: false
       type: text
     - default: ''
@@ -145,15 +118,6 @@ additionalProperties:
       envKey: WOODPECKER_GITHUB_CLIENT
       labelEn: Github CLIENT Vaule
       labelZh: Github CLIENT 值
-      label:
-        en: 'Github CLIENT Vaule'
-        zh: 'Github CLIENT 值'
-        zh-Hant: 'Github CLIENT 值'
-        ja: 'Github CLIENT 値'
-        ko: 'Github CLIENT 값'
-        ru: 'Значение Github CLIENT'
-        ms: 'Nilai Github CLIENT'
-        pt-br: 'Valor do Github CLIENT'
       label:
         en: 'Github CLIENT Vaule'
         zh: 'Github CLIENT 值'
@@ -179,15 +143,6 @@ additionalProperties:
         ru: 'Значение Github SECRET'
         ms: 'Nilai Github SECRET'
         pt-br: 'Valor do Github SECRET'
-      label:
-        en: 'Github SECRET Vaule'
-        zh: 'Github SECRET 值'
-        zh-Hant: 'Github SECRET 值'
-        ja: 'Github SECRET 値'
-        ko: 'Github SECRET 값'
-        ru: 'Значение Github SECRET'
-        ms: 'Nilai Github SECRET'
-        pt-br: 'Valor do Github SECRET'
       required: false
       type: text
     - default: "false"
@@ -195,15 +150,6 @@ additionalProperties:
       envKey: GITEA_ENABLE_SWITCH
       labelEn: Enable Gitea (true or false)
       labelZh: 启用Gitea(true/false)
-      label:
-        en: 'Enable Gitea (true or false)'
-        zh: '启用Gitea(true/false)'
-        zh-Hant: '啟用Gitea(true/false)'
-        ja: 'Gitea を有効化（true/false）'
-        ko: 'Gitea 활성화(true/false)'
-        ru: 'Включить Gitea (true/false)'
-        ms: 'Dayakan Gitea (true/false)'
-        pt-br: 'Ativar Gitea (true/false)'
       label:
         en: 'Enable Gitea (true or false)'
         zh: '启用Gitea(true/false)'
@@ -229,15 +175,6 @@ additionalProperties:
         ru: 'URL Gitea'
         ms: 'URL Gitea'
         pt-br: 'URL do Gitea'
-      label:
-        en: 'Gitea URL'
-        zh: 'Gitea地址'
-        zh-Hant: 'Gitea 地址'
-        ja: 'Gitea の URL'
-        ko: 'Gitea URL 주소'
-        ru: 'URL Gitea'
-        ms: 'URL Gitea'
-        pt-br: 'URL do Gitea'
       required: false
       type: text
     - default: ''
@@ -245,15 +182,6 @@ additionalProperties:
       envKey: WOODPECKER_GITEA_CLIENT
       labelEn: Gitea CLIENT Vaule
       labelZh: Gitea CLIENT 值
-      label:
-        en: 'Gitea CLIENT Vaule'
-        zh: 'Gitea CLIENT 值'
-        zh-Hant: 'Gitea CLIENT 值'
-        ja: 'Gitea CLIENT 値'
-        ko: 'Gitea CLIENT 값'
-        ru: 'Значение Gitea CLIENT'
-        ms: 'Nilai Gitea CLIENT'
-        pt-br: 'Valor do Gitea CLIENT'
       label:
         en: 'Gitea CLIENT Vaule'
         zh: 'Gitea CLIENT 值'
@@ -279,15 +207,6 @@ additionalProperties:
         ru: 'Значение Gitea SECRET'
         ms: 'Nilai Gitea SECRET'
         pt-br: 'Valor do Gitea SECRET'
-      label:
-        en: 'Gitea SECRET Vaule'
-        zh: 'Gitea SECRET 值'
-        zh-Hant: 'Gitea SECRET 值'
-        ja: 'Gitea SECRET 値'
-        ko: 'Gitea SECRET 값'
-        ru: 'Значение Gitea SECRET'
-        ms: 'Nilai Gitea SECRET'
-        pt-br: 'Valor do Gitea SECRET'
       required: false
       type: text
     - default: "false"
@@ -295,15 +214,6 @@ additionalProperties:
       envKey: GITLAB_ENABLE_SWITCH
       labelEn: Enable GitLab (true or false)
       labelZh: 启用GitLab (true/false)
-      label:
-        en: 'Enable GitLab (true or false)'
-        zh: '启用GitLab (true/false)'
-        zh-Hant: '啟用GitLab (true/false)'
-        ja: 'GitLab を有効化（true/false）'
-        ko: 'GitLab 활성화(true/false)'
-        ru: 'Включить GitLab (true/false)'
-        ms: 'Dayakan GitLab (true/false)'
-        pt-br: 'Ativar GitLab (true/false)'
       label:
         en: 'Enable GitLab (true or false)'
         zh: '启用GitLab (true/false)'
@@ -329,15 +239,6 @@ additionalProperties:
         ru: 'URL GitLab'
         ms: 'URL GitLab'
         pt-br: 'URL do GitLab'
-      label:
-        en: 'GitLab URL'
-        zh: 'GitLab 地址'
-        zh-Hant: 'GitLab 地址'
-        ja: 'GitLab の URL'
-        ko: 'GitLab URL 주소'
-        ru: 'URL GitLab'
-        ms: 'URL GitLab'
-        pt-br: 'URL do GitLab'
       required: false
       type: text
     - default: ''
@@ -345,15 +246,6 @@ additionalProperties:
       envKey: WOODPECKER_GITLAB_CLIENT
       labelEn: GitLab CLIENT Vaule
       labelZh: GitLab CLIENT 值
-      label:
-        en: 'GitLab CLIENT Vaule'
-        zh: 'GitLab CLIENT 值'
-        zh-Hant: 'GitLab CLIENT 值'
-        ja: 'GitLab CLIENT 値'
-        ko: 'GitLab CLIENT 값'
-        ru: 'Значение GitLab CLIENT'
-        ms: 'Nilai GitLab CLIENT'
-        pt-br: 'Valor do GitLab CLIENT'
       label:
         en: 'GitLab CLIENT Vaule'
         zh: 'GitLab CLIENT 值'
@@ -379,15 +271,6 @@ additionalProperties:
         ru: 'Значение GitLab SECRET'
         ms: 'Nilai GitLab SECRET'
         pt-br: 'Valor do GitLab SECRET'
-      label:
-        en: 'GitLab SECRET Vaule'
-        zh: 'GitLab SECRET 值'
-        zh-Hant: 'GitLab SECRET 值'
-        ja: 'GitLab SECRET 値'
-        ko: 'GitLab SECRET 값'
-        ru: 'Значение GitLab SECRET'
-        ms: 'Nilai GitLab SECRET'
-        pt-br: 'Valor do GitLab SECRET'
       required: false
       type: text
     - default: "false"
@@ -395,15 +278,6 @@ additionalProperties:
       envKey: BITBUCKET_ENABLE_SWITCH
       labelEn: Enable Bitbucket (true or false)
       labelZh: 启用 Bitbucket (true/false)
-      label:
-        en: 'Enable Bitbucket (true or false)'
-        zh: '启用 Bitbucket (true/false)'
-        zh-Hant: '啟用 Bitbucket (true/false)'
-        ja: 'Bitbucket を有効化（true/false）'
-        ko: 'Bitbucket 활성화(true/false)'
-        ru: 'Включить Bitbucket (true/false)'
-        ms: 'Dayakan Bitbucket (true/false)'
-        pt-br: 'Ativar Bitbucket (true/false)'
       label:
         en: 'Enable Bitbucket (true or false)'
         zh: '启用 Bitbucket (true/false)'
@@ -429,15 +303,6 @@ additionalProperties:
         ru: 'Значение Bitbucket CLIENT'
         ms: 'Nilai Bitbucket CLIENT'
         pt-br: 'Valor do Bitbucket CLIENT'
-      label:
-        en: 'Bitbucket CLIENT Value'
-        zh: 'Bitbucket CLIENT 值'
-        zh-Hant: 'Bitbucket CLIENT 值'
-        ja: 'Bitbucket CLIENT 値'
-        ko: 'Bitbucket CLIENT 값'
-        ru: 'Значение Bitbucket CLIENT'
-        ms: 'Nilai Bitbucket CLIENT'
-        pt-br: 'Valor do Bitbucket CLIENT'
       required: false
       type: text
     - default: ''
@@ -445,15 +310,6 @@ additionalProperties:
       envKey: WOODPECKER_BITBUCKET_SECRET
       labelEn: Bitbucket SECRET Value
       labelZh: Bitbucket SECRET 值
-      label:
-        en: 'Bitbucket SECRET Value'
-        zh: 'Bitbucket SECRET 值'
-        zh-Hant: 'Bitbucket SECRET 值'
-        ja: 'Bitbucket SECRET 値'
-        ko: 'Bitbucket SECRET 값'
-        ru: 'Значение Bitbucket SECRET'
-        ms: 'Nilai Bitbucket SECRET'
-        pt-br: 'Valor do Bitbucket SECRET'
       label:
         en: 'Bitbucket SECRET Value'
         zh: 'Bitbucket SECRET 值'

--- a/apps/woodpecker/latest/data.yml
+++ b/apps/woodpecker/latest/data.yml
@@ -5,15 +5,6 @@ additionalProperties:
       envKey: PANEL_APP_PORT_HTTP
       labelEn: Port
       labelZh: 端口
-      label:
-        en: 'Port'
-        zh: '端口'
-        zh-Hant: '埠'
-        ja: 'ポート'
-        ko: '포트'
-        ru: 'Порт'
-        ms: 'Port'
-        pt-br: 'Porta'
       required: true
       rule: paramPort
       type: number
@@ -22,15 +13,6 @@ additionalProperties:
       envKey: DATA_PATH
       labelEn: Data folder path
       labelZh: 数据文件夹路径
-      label:
-        en: 'Data folder path'
-        zh: '数据文件夹路径'
-        zh-Hant: '資料夾路徑'
-        ja: 'データフォルダパス'
-        ko: '데이터 폴더 경로'
-        ru: 'Путь к папке данных'
-        ms: 'Laluan folder data'
-        pt-br: 'Caminho da pasta de dados'
       required: true
       type: text
     - default: "false"
@@ -38,15 +20,6 @@ additionalProperties:
       envKey: REGISTER_SWITCH
       labelEn: Enable register (true or false)
       labelZh: 启用注册(true/false)
-      label:
-        en: 'Enable register (true or false)'
-        zh: '启用注册(true/false)'
-        zh-Hant: '啟用註冊(true/false)'
-        ja: '登録を有効化（true/false）'
-        ko: '등록 활성화(true/false)'
-        ru: 'Включить регистрацию (true/false)'
-        ms: 'Dayakan pendaftaran (true/false)'
-        pt-br: 'Ativar registro (true/false)'
       required: true
       type: text
     - default: http://ci.example.com
@@ -54,15 +27,6 @@ additionalProperties:
       envKey: WOODPECKER_HOST
       labelEn: External URL
       labelZh: 外部访问地址
-      label:
-        en: 'External URL'
-        zh: '外部访问地址'
-        zh-Hant: '外部訪問地址'
-        ja: '外部 URL'
-        ko: '외부 URL'
-        ru: 'Внешний URL'
-        ms: 'URL luaran'
-        pt-br: 'URL externa'
       required: true
       type: text
     - default: ''
@@ -70,15 +34,6 @@ additionalProperties:
       envKey: WOODPECKER_AGENT_SECRET
       labelEn: Github Agent Secret Vaule
       labelZh: Github Agent Secret 值
-      label:
-        en: 'Github Agent Secret Vaule'
-        zh: 'Github Agent Secret 值'
-        zh-Hant: 'Github Agent Secret 值'
-        ja: 'Github Agent Secret 値'
-        ko: 'Github Agent Secret 값'
-        ru: 'Значение Github Agent Secret'
-        ms: 'Nilai Github Agent Secret'
-        pt-br: 'Valor do Github Agent Secret'
       required: true
       type: text
     - default: "true"
@@ -86,15 +41,6 @@ additionalProperties:
       envKey: GITHUB_ENABLE_SWITCH
       labelEn: Enable Github (true or false)
       labelZh: 启用Github(true/false)
-      label:
-        en: 'Enable Github (true or false)'
-        zh: '启用Github(true/false)'
-        zh-Hant: '啟用Github(true/false)'
-        ja: 'Github を有効化（true/false）'
-        ko: 'Github 활성화(true/false)'
-        ru: 'Включить Github (true/false)'
-        ms: 'Dayakan Github (true/false)'
-        pt-br: 'Ativar Github (true/false)'
       required: true
       type: text
     - default: https://github.com
@@ -102,15 +48,6 @@ additionalProperties:
       envKey: WOODPECKER_GITHUB_URL
       labelEn: Github URL
       labelZh: Github地址
-      label:
-        en: 'Github URL'
-        zh: 'Github地址'
-        zh-Hant: 'Github 地址'
-        ja: 'Github の URL'
-        ko: 'Github URL 주소'
-        ru: 'URL Github'
-        ms: 'URL Github'
-        pt-br: 'URL do Github'
       required: false
       type: text
     - default: ''
@@ -118,15 +55,6 @@ additionalProperties:
       envKey: WOODPECKER_GITHUB_CLIENT
       labelEn: Github CLIENT Vaule
       labelZh: Github CLIENT 值
-      label:
-        en: 'Github CLIENT Vaule'
-        zh: 'Github CLIENT 值'
-        zh-Hant: 'Github CLIENT 值'
-        ja: 'Github CLIENT 値'
-        ko: 'Github CLIENT 값'
-        ru: 'Значение Github CLIENT'
-        ms: 'Nilai Github CLIENT'
-        pt-br: 'Valor do Github CLIENT'
       required: false
       type: text
     - default: ''
@@ -134,15 +62,6 @@ additionalProperties:
       envKey: WOODPECKER_GITHUB_SECRET
       labelEn: Github SECRET Vaule
       labelZh: Github SECRET 值
-      label:
-        en: 'Github SECRET Vaule'
-        zh: 'Github SECRET 值'
-        zh-Hant: 'Github SECRET 值'
-        ja: 'Github SECRET 値'
-        ko: 'Github SECRET 값'
-        ru: 'Значение Github SECRET'
-        ms: 'Nilai Github SECRET'
-        pt-br: 'Valor do Github SECRET'
       required: false
       type: text
     - default: "false"
@@ -150,15 +69,6 @@ additionalProperties:
       envKey: GITEA_ENABLE_SWITCH
       labelEn: Enable Gitea (true or false)
       labelZh: 启用Gitea(true/false)
-      label:
-        en: 'Enable Gitea (true or false)'
-        zh: '启用Gitea(true/false)'
-        zh-Hant: '啟用Gitea(true/false)'
-        ja: 'Gitea を有効化（true/false）'
-        ko: 'Gitea 활성화(true/false)'
-        ru: 'Включить Gitea (true/false)'
-        ms: 'Dayakan Gitea (true/false)'
-        pt-br: 'Ativar Gitea (true/false)'
       required: true
       type: text
     - default: https://try.gitea.io
@@ -166,15 +76,6 @@ additionalProperties:
       envKey: WOODPECKER_GITEA_URL
       labelEn: Gitea URL
       labelZh: Gitea地址
-      label:
-        en: 'Gitea URL'
-        zh: 'Gitea地址'
-        zh-Hant: 'Gitea 地址'
-        ja: 'Gitea の URL'
-        ko: 'Gitea URL 주소'
-        ru: 'URL Gitea'
-        ms: 'URL Gitea'
-        pt-br: 'URL do Gitea'
       required: false
       type: text
     - default: ''
@@ -182,15 +83,6 @@ additionalProperties:
       envKey: WOODPECKER_GITEA_CLIENT
       labelEn: Gitea CLIENT Vaule
       labelZh: Gitea CLIENT 值
-      label:
-        en: 'Gitea CLIENT Vaule'
-        zh: 'Gitea CLIENT 值'
-        zh-Hant: 'Gitea CLIENT 值'
-        ja: 'Gitea CLIENT 値'
-        ko: 'Gitea CLIENT 값'
-        ru: 'Значение Gitea CLIENT'
-        ms: 'Nilai Gitea CLIENT'
-        pt-br: 'Valor do Gitea CLIENT'
       required: false
       type: text
     - default: ''
@@ -198,15 +90,6 @@ additionalProperties:
       envKey: WOODPECKER_GITEA_SECRET
       labelEn: Gitea SECRET Vaule
       labelZh: Gitea SECRET 值
-      label:
-        en: 'Gitea SECRET Vaule'
-        zh: 'Gitea SECRET 值'
-        zh-Hant: 'Gitea SECRET 值'
-        ja: 'Gitea SECRET 値'
-        ko: 'Gitea SECRET 값'
-        ru: 'Значение Gitea SECRET'
-        ms: 'Nilai Gitea SECRET'
-        pt-br: 'Valor do Gitea SECRET'
       required: false
       type: text
     - default: "false"
@@ -214,15 +97,6 @@ additionalProperties:
       envKey: GITLAB_ENABLE_SWITCH
       labelEn: Enable GitLab (true or false)
       labelZh: 启用GitLab (true/false)
-      label:
-        en: 'Enable GitLab (true or false)'
-        zh: '启用GitLab (true/false)'
-        zh-Hant: '啟用GitLab (true/false)'
-        ja: 'GitLab を有効化（true/false）'
-        ko: 'GitLab 활성화(true/false)'
-        ru: 'Включить GitLab (true/false)'
-        ms: 'Dayakan GitLab (true/false)'
-        pt-br: 'Ativar GitLab (true/false)'
       required: true
       type: text
     - default: https://gitlab.com
@@ -230,15 +104,6 @@ additionalProperties:
       envKey: WOODPECKER_GITLAB_URL
       labelEn: GitLab URL
       labelZh: GitLab 地址
-      label:
-        en: 'GitLab URL'
-        zh: 'GitLab 地址'
-        zh-Hant: 'GitLab 地址'
-        ja: 'GitLab の URL'
-        ko: 'GitLab URL 주소'
-        ru: 'URL GitLab'
-        ms: 'URL GitLab'
-        pt-br: 'URL do GitLab'
       required: false
       type: text
     - default: ''
@@ -246,15 +111,6 @@ additionalProperties:
       envKey: WOODPECKER_GITLAB_CLIENT
       labelEn: GitLab CLIENT Vaule
       labelZh: GitLab CLIENT 值
-      label:
-        en: 'GitLab CLIENT Vaule'
-        zh: 'GitLab CLIENT 值'
-        zh-Hant: 'GitLab CLIENT 值'
-        ja: 'GitLab CLIENT 値'
-        ko: 'GitLab CLIENT 값'
-        ru: 'Значение GitLab CLIENT'
-        ms: 'Nilai GitLab CLIENT'
-        pt-br: 'Valor do GitLab CLIENT'
       required: false
       type: text
     - default: ''
@@ -262,15 +118,6 @@ additionalProperties:
       envKey: WOODPECKER_GITLAB_SECRET
       labelEn: GitLab SECRET Vaule
       labelZh: GitLab SECRET 值
-      label:
-        en: 'GitLab SECRET Vaule'
-        zh: 'GitLab SECRET 值'
-        zh-Hant: 'GitLab SECRET 值'
-        ja: 'GitLab SECRET 値'
-        ko: 'GitLab SECRET 값'
-        ru: 'Значение GitLab SECRET'
-        ms: 'Nilai GitLab SECRET'
-        pt-br: 'Valor do GitLab SECRET'
       required: false
       type: text
     - default: "false"
@@ -278,15 +125,6 @@ additionalProperties:
       envKey: BITBUCKET_ENABLE_SWITCH
       labelEn: Enable Bitbucket (true or false)
       labelZh: 启用 Bitbucket (true/false)
-      label:
-        en: 'Enable Bitbucket (true or false)'
-        zh: '启用 Bitbucket (true/false)'
-        zh-Hant: '啟用 Bitbucket (true/false)'
-        ja: 'Bitbucket を有効化（true/false）'
-        ko: 'Bitbucket 활성화(true/false)'
-        ru: 'Включить Bitbucket (true/false)'
-        ms: 'Dayakan Bitbucket (true/false)'
-        pt-br: 'Ativar Bitbucket (true/false)'
       required: true
       type: text
     - default: ''
@@ -294,15 +132,6 @@ additionalProperties:
       envKey: WOODPECKER_BITBUCKET_CLIENT
       labelEn: Bitbucket CLIENT Value
       labelZh: Bitbucket CLIENT 值
-      label:
-        en: 'Bitbucket CLIENT Value'
-        zh: 'Bitbucket CLIENT 值'
-        zh-Hant: 'Bitbucket CLIENT 值'
-        ja: 'Bitbucket CLIENT 値'
-        ko: 'Bitbucket CLIENT 값'
-        ru: 'Значение Bitbucket CLIENT'
-        ms: 'Nilai Bitbucket CLIENT'
-        pt-br: 'Valor do Bitbucket CLIENT'
       required: false
       type: text
     - default: ''
@@ -310,14 +139,5 @@ additionalProperties:
       envKey: WOODPECKER_BITBUCKET_SECRET
       labelEn: Bitbucket SECRET Value
       labelZh: Bitbucket SECRET 值
-      label:
-        en: 'Bitbucket SECRET Value'
-        zh: 'Bitbucket SECRET 值'
-        zh-Hant: 'Bitbucket SECRET 值'
-        ja: 'Bitbucket SECRET 値'
-        ko: 'Bitbucket SECRET 값'
-        ru: 'Значение Bitbucket SECRET'
-        ms: 'Nilai Bitbucket SECRET'
-        pt-br: 'Valor do Bitbucket SECRET'
       required: false
       type: text

--- a/apps/woodpecker/latest/data.yml
+++ b/apps/woodpecker/latest/data.yml
@@ -79,15 +79,6 @@ additionalProperties:
         ru: 'Значение Github Agent Secret'
         ms: 'Nilai Github Agent Secret'
         pt-br: 'Valor do Github Agent Secret'
-      label:
-        en: 'Github Agent Secret Vaule'
-        zh: 'Github Agent Secret 值'
-        zh-Hant: 'Github Agent Secret 值'
-        ja: 'Github Agent Secret 値'
-        ko: 'Github Agent Secret 값'
-        ru: 'Значение Github Agent Secret'
-        ms: 'Nilai Github Agent Secret'
-        pt-br: 'Valor do Github Agent Secret'
       required: true
       type: text
     - default: "true"
@@ -95,15 +86,6 @@ additionalProperties:
       envKey: GITHUB_ENABLE_SWITCH
       labelEn: Enable Github (true or false)
       labelZh: 启用Github(true/false)
-      label:
-        en: 'Enable Github (true or false)'
-        zh: '启用Github(true/false)'
-        zh-Hant: '啟用Github(true/false)'
-        ja: 'Github を有効化（true/false）'
-        ko: 'Github 활성화(true/false)'
-        ru: 'Включить Github (true/false)'
-        ms: 'Dayakan Github (true/false)'
-        pt-br: 'Ativar Github (true/false)'
       label:
         en: 'Enable Github (true or false)'
         zh: '启用Github(true/false)'
@@ -129,15 +111,6 @@ additionalProperties:
         ru: 'URL Github'
         ms: 'URL Github'
         pt-br: 'URL do Github'
-      label:
-        en: 'Github URL'
-        zh: 'Github地址'
-        zh-Hant: 'Github 地址'
-        ja: 'Github の URL'
-        ko: 'Github URL 주소'
-        ru: 'URL Github'
-        ms: 'URL Github'
-        pt-br: 'URL do Github'
       required: false
       type: text
     - default: ''
@@ -145,15 +118,6 @@ additionalProperties:
       envKey: WOODPECKER_GITHUB_CLIENT
       labelEn: Github CLIENT Vaule
       labelZh: Github CLIENT 值
-      label:
-        en: 'Github CLIENT Vaule'
-        zh: 'Github CLIENT 值'
-        zh-Hant: 'Github CLIENT 值'
-        ja: 'Github CLIENT 値'
-        ko: 'Github CLIENT 값'
-        ru: 'Значение Github CLIENT'
-        ms: 'Nilai Github CLIENT'
-        pt-br: 'Valor do Github CLIENT'
       label:
         en: 'Github CLIENT Vaule'
         zh: 'Github CLIENT 值'
@@ -179,15 +143,6 @@ additionalProperties:
         ru: 'Значение Github SECRET'
         ms: 'Nilai Github SECRET'
         pt-br: 'Valor do Github SECRET'
-      label:
-        en: 'Github SECRET Vaule'
-        zh: 'Github SECRET 值'
-        zh-Hant: 'Github SECRET 值'
-        ja: 'Github SECRET 値'
-        ko: 'Github SECRET 값'
-        ru: 'Значение Github SECRET'
-        ms: 'Nilai Github SECRET'
-        pt-br: 'Valor do Github SECRET'
       required: false
       type: text
     - default: "false"
@@ -195,15 +150,6 @@ additionalProperties:
       envKey: GITEA_ENABLE_SWITCH
       labelEn: Enable Gitea (true or false)
       labelZh: 启用Gitea(true/false)
-      label:
-        en: 'Enable Gitea (true or false)'
-        zh: '启用Gitea(true/false)'
-        zh-Hant: '啟用Gitea(true/false)'
-        ja: 'Gitea を有効化（true/false）'
-        ko: 'Gitea 활성화(true/false)'
-        ru: 'Включить Gitea (true/false)'
-        ms: 'Dayakan Gitea (true/false)'
-        pt-br: 'Ativar Gitea (true/false)'
       label:
         en: 'Enable Gitea (true or false)'
         zh: '启用Gitea(true/false)'
@@ -229,15 +175,6 @@ additionalProperties:
         ru: 'URL Gitea'
         ms: 'URL Gitea'
         pt-br: 'URL do Gitea'
-      label:
-        en: 'Gitea URL'
-        zh: 'Gitea地址'
-        zh-Hant: 'Gitea 地址'
-        ja: 'Gitea の URL'
-        ko: 'Gitea URL 주소'
-        ru: 'URL Gitea'
-        ms: 'URL Gitea'
-        pt-br: 'URL do Gitea'
       required: false
       type: text
     - default: ''
@@ -245,15 +182,6 @@ additionalProperties:
       envKey: WOODPECKER_GITEA_CLIENT
       labelEn: Gitea CLIENT Vaule
       labelZh: Gitea CLIENT 值
-      label:
-        en: 'Gitea CLIENT Vaule'
-        zh: 'Gitea CLIENT 值'
-        zh-Hant: 'Gitea CLIENT 值'
-        ja: 'Gitea CLIENT 値'
-        ko: 'Gitea CLIENT 값'
-        ru: 'Значение Gitea CLIENT'
-        ms: 'Nilai Gitea CLIENT'
-        pt-br: 'Valor do Gitea CLIENT'
       label:
         en: 'Gitea CLIENT Vaule'
         zh: 'Gitea CLIENT 值'
@@ -279,15 +207,6 @@ additionalProperties:
         ru: 'Значение Gitea SECRET'
         ms: 'Nilai Gitea SECRET'
         pt-br: 'Valor do Gitea SECRET'
-      label:
-        en: 'Gitea SECRET Vaule'
-        zh: 'Gitea SECRET 值'
-        zh-Hant: 'Gitea SECRET 值'
-        ja: 'Gitea SECRET 値'
-        ko: 'Gitea SECRET 값'
-        ru: 'Значение Gitea SECRET'
-        ms: 'Nilai Gitea SECRET'
-        pt-br: 'Valor do Gitea SECRET'
       required: false
       type: text
     - default: "false"
@@ -295,15 +214,6 @@ additionalProperties:
       envKey: GITLAB_ENABLE_SWITCH
       labelEn: Enable GitLab (true or false)
       labelZh: 启用GitLab (true/false)
-      label:
-        en: 'Enable GitLab (true or false)'
-        zh: '启用GitLab (true/false)'
-        zh-Hant: '啟用GitLab (true/false)'
-        ja: 'GitLab を有効化（true/false）'
-        ko: 'GitLab 활성화(true/false)'
-        ru: 'Включить GitLab (true/false)'
-        ms: 'Dayakan GitLab (true/false)'
-        pt-br: 'Ativar GitLab (true/false)'
       label:
         en: 'Enable GitLab (true or false)'
         zh: '启用GitLab (true/false)'
@@ -329,15 +239,6 @@ additionalProperties:
         ru: 'URL GitLab'
         ms: 'URL GitLab'
         pt-br: 'URL do GitLab'
-      label:
-        en: 'GitLab URL'
-        zh: 'GitLab 地址'
-        zh-Hant: 'GitLab 地址'
-        ja: 'GitLab の URL'
-        ko: 'GitLab URL 주소'
-        ru: 'URL GitLab'
-        ms: 'URL GitLab'
-        pt-br: 'URL do GitLab'
       required: false
       type: text
     - default: ''
@@ -345,15 +246,6 @@ additionalProperties:
       envKey: WOODPECKER_GITLAB_CLIENT
       labelEn: GitLab CLIENT Vaule
       labelZh: GitLab CLIENT 值
-      label:
-        en: 'GitLab CLIENT Vaule'
-        zh: 'GitLab CLIENT 值'
-        zh-Hant: 'GitLab CLIENT 值'
-        ja: 'GitLab CLIENT 値'
-        ko: 'GitLab CLIENT 값'
-        ru: 'Значение GitLab CLIENT'
-        ms: 'Nilai GitLab CLIENT'
-        pt-br: 'Valor do GitLab CLIENT'
       label:
         en: 'GitLab CLIENT Vaule'
         zh: 'GitLab CLIENT 值'
@@ -379,15 +271,6 @@ additionalProperties:
         ru: 'Значение GitLab SECRET'
         ms: 'Nilai GitLab SECRET'
         pt-br: 'Valor do GitLab SECRET'
-      label:
-        en: 'GitLab SECRET Vaule'
-        zh: 'GitLab SECRET 值'
-        zh-Hant: 'GitLab SECRET 值'
-        ja: 'GitLab SECRET 値'
-        ko: 'GitLab SECRET 값'
-        ru: 'Значение GitLab SECRET'
-        ms: 'Nilai GitLab SECRET'
-        pt-br: 'Valor do GitLab SECRET'
       required: false
       type: text
     - default: "false"
@@ -395,15 +278,6 @@ additionalProperties:
       envKey: BITBUCKET_ENABLE_SWITCH
       labelEn: Enable Bitbucket (true or false)
       labelZh: 启用 Bitbucket (true/false)
-      label:
-        en: 'Enable Bitbucket (true or false)'
-        zh: '启用 Bitbucket (true/false)'
-        zh-Hant: '啟用 Bitbucket (true/false)'
-        ja: 'Bitbucket を有効化（true/false）'
-        ko: 'Bitbucket 활성화(true/false)'
-        ru: 'Включить Bitbucket (true/false)'
-        ms: 'Dayakan Bitbucket (true/false)'
-        pt-br: 'Ativar Bitbucket (true/false)'
       label:
         en: 'Enable Bitbucket (true or false)'
         zh: '启用 Bitbucket (true/false)'
@@ -429,15 +303,6 @@ additionalProperties:
         ru: 'Значение Bitbucket CLIENT'
         ms: 'Nilai Bitbucket CLIENT'
         pt-br: 'Valor do Bitbucket CLIENT'
-      label:
-        en: 'Bitbucket CLIENT Value'
-        zh: 'Bitbucket CLIENT 值'
-        zh-Hant: 'Bitbucket CLIENT 值'
-        ja: 'Bitbucket CLIENT 値'
-        ko: 'Bitbucket CLIENT 값'
-        ru: 'Значение Bitbucket CLIENT'
-        ms: 'Nilai Bitbucket CLIENT'
-        pt-br: 'Valor do Bitbucket CLIENT'
       required: false
       type: text
     - default: ''
@@ -445,15 +310,6 @@ additionalProperties:
       envKey: WOODPECKER_BITBUCKET_SECRET
       labelEn: Bitbucket SECRET Value
       labelZh: Bitbucket SECRET 值
-      label:
-        en: 'Bitbucket SECRET Value'
-        zh: 'Bitbucket SECRET 值'
-        zh-Hant: 'Bitbucket SECRET 值'
-        ja: 'Bitbucket SECRET 値'
-        ko: 'Bitbucket SECRET 값'
-        ru: 'Значение Bitbucket SECRET'
-        ms: 'Nilai Bitbucket SECRET'
-        pt-br: 'Valor do Bitbucket SECRET'
       label:
         en: 'Bitbucket SECRET Value'
         zh: 'Bitbucket SECRET 值'


### PR DESCRIPTION
## Summary
- remove invalid localized `label:` maps from affected version `data.yml` files
- keep `labelEn` / `labelZh` so 1Panel can parse values as strings
- cover autoheal/openclaw/plex/radarr/sonarr/wewe-rss/woodpecker import failures

## Validation
- `validate-v2.sh --strict-store` PASS for autoheal/openclaw/plex/radarr/sonarr/wewe-rss/woodpecker
- new test container: `moelin/1panel:global-v1.10.34-lts`
- host port: `10089`
- base_dir: `/home/node/1panel-test-10089`
- `1panel app init` succeeded for all 10 affected versions

[openclaw]