### PR TITLE
[openclaw] fix local app import parse errors for 1Panel

### DIFF
--- a/apps/openclaw/2026.4.11-sandbox/data.yml
+++ b/apps/openclaw/2026.4.11-sandbox/data.yml
@@ -93,15 +93,6 @@ additionalProperties:
           value: "custom"
         - label: "auto"
           value: "auto"
-      label:
-        en: OpenClaw Gateway Bind
-        ja: OpenClaw ゲートウェイバインド
-        ms: Ikatan Gateway OpenClaw
-        pt-br: Vinculação do Gateway OpenClaw
-        ru: Привязка шлюза OpenClaw
-        ko: OpenClaw 게이트웨이 바인드
-        zh-Hant: OpenClaw 網關綁定
-        zh: OpenClaw 网关绑定
     - default: "local"
       disabled: true
       envKey: OPENCLAW_MODE

--- a/apps/openclaw/2026.4.11/data.yml
+++ b/apps/openclaw/2026.4.11/data.yml
@@ -93,15 +93,6 @@ additionalProperties:
           value: "custom"
         - label: "auto"
           value: "auto"
-      label:
-        en: OpenClaw Gateway Bind
-        ja: OpenClaw ゲートウェイバインド
-        ms: Ikatan Gateway OpenClaw
-        pt-br: Vinculação do Gateway OpenClaw
-        ru: Привязка шлюза OpenClaw
-        ko: OpenClaw 게이트웨이 바인드
-        zh-Hant: OpenClaw 網關綁定
-        zh: OpenClaw 网关绑定
     - default: "local"
       disabled: true
       envKey: OPENCLAW_MODE

--- a/apps/plex/official-latest/data.yml
+++ b/apps/plex/official-latest/data.yml
@@ -315,25 +315,9 @@ additionalProperties:
       type: select
       edit: true
       values:
-        - label:
-            en: 'True'
-            zh: '是'
-            zh-Hant: '是'
-            ja: 'はい'
-            ko: '예'
-            ru: 'Да'
-            ms: 'Ya'
-            pt-br: 'Sim'
+        - label: "True"
           value: "true"
-        - label:
-            en: 'False'
-            zh: '否'
-            zh-Hant: '否'
-            ja: 'いいえ'
-            ko: '아니요'
-            ru: 'Нет'
-            ms: 'Tidak'
-            pt-br: 'Não'
+        - label: "False"
           value: "false"
     - default: "192.168.1.0/24,172.18.0.0/16"
       edit: true

--- a/apps/radarr/6.0.4/data.yml
+++ b/apps/radarr/6.0.4/data.yml
@@ -79,15 +79,6 @@ additionalProperties:
         ru: 'Путь к конфигурации Radarr'
         ms: 'Laluan konfigurasi Radarr'
         pt-br: 'Caminho de configuração do Radarr'
-      label:
-        en: 'Radarr Config Path'
-        zh: 'Radarr 配置路径'
-        zh-Hant: 'Radarr 配置路徑'
-        ja: 'Radarr 設定パス'
-        ko: 'Radarr 구성 경로'
-        ru: 'Путь к конфигурации Radarr'
-        ms: 'Laluan konfigurasi Radarr'
-        pt-br: 'Caminho de configuração do Radarr'
       required: true
       type: text
     - default: "./data/movies"
@@ -104,15 +95,6 @@ additionalProperties:
         ru: 'Путь к фильмам'
         ms: 'Laluan filem'
         pt-br: 'Caminho de filmes'
-      label:
-        en: 'Movies Path'
-        zh: '电影路径'
-        zh-Hant: '電影路徑'
-        ja: '映画パス'
-        ko: '영화 경로'
-        ru: 'Путь к фильмам'
-        ms: 'Laluan filem'
-        pt-br: 'Caminho dos filmes'
       required: true
       type: text
     - default: "./data/downloads"

--- a/apps/sonarr/4.0.17/data.yml
+++ b/apps/sonarr/4.0.17/data.yml
@@ -79,15 +79,6 @@ additionalProperties:
         ru: 'Путь к конфигурации Sonarr'
         ms: 'Laluan konfigurasi Sonarr'
         pt-br: 'Caminho de configuração do Sonarr'
-      label:
-        en: 'Sonarr Config Path'
-        zh: 'Sonarr 配置路径'
-        zh-Hant: 'Sonarr 配置路徑'
-        ja: 'Sonarr 設定パス'
-        ko: 'Sonarr 구성 경로'
-        ru: 'Путь к конфигурации Sonarr'
-        ms: 'Laluan konfigurasi Sonarr'
-        pt-br: 'Caminho de configuração do Sonarr'
       required: true
       type: text
     - default: "./data/tv"
@@ -95,15 +86,6 @@ additionalProperties:
       envKey: TV_SERIES_PATH
       labelEn: TV Series Path
       labelZh: 电视剧路径
-      label:
-        en: 'TV Series Path'
-        zh: '电视剧路径'
-        zh-Hant: '電視劇路徑'
-        ja: 'テレビシリーズパス'
-        ko: 'TV 시리즈 경로'
-        ru: 'Путь к сериалам'
-        ms: 'Laluan siri TV'
-        pt-br: 'Caminho das séries de TV'
       label:
         en: 'TV Series Path'
         zh: '电视剧路径'

--- a/apps/wewe-rss/latest-mysql/data.yml
+++ b/apps/wewe-rss/latest-mysql/data.yml
@@ -21,25 +21,9 @@ additionalProperties:
       required: true
       type: apps
       values:
-        - label:
-            en: 'MySQL'
-            zh: 'MySQL'
-            zh-Hant: 'MySQL'
-            ja: 'MySQL'
-            ko: 'MySQL'
-            ru: 'MySQL'
-            ms: 'MySQL'
-            pt-br: 'MySQL'
+        - label: "MySQL"
           value: mysql
-        - label:
-            en: 'LocalMySQL'
-            zh: 'LocalMySQL'
-            zh-Hant: 'LocalMySQL'
-            ja: 'LocalMySQL'
-            ko: 'LocalMySQL'
-            ru: 'LocalMySQL'
-            ms: 'LocalMySQL'
-            pt-br: 'LocalMySQL'
+        - label: "LocalMySQL"
           value: localmysql
     - default: "wewe-rss"
       envKey: PANEL_DB_NAME

--- a/apps/woodpecker/3.13.0/data.yml
+++ b/apps/woodpecker/3.13.0/data.yml
@@ -79,15 +79,6 @@ additionalProperties:
         ru: 'Значение Github Agent Secret'
         ms: 'Nilai Github Agent Secret'
         pt-br: 'Valor do Github Agent Secret'
-      label:
-        en: 'Github Agent Secret Vaule'
-        zh: 'Github Agent Secret 值'
-        zh-Hant: 'Github Agent Secret 值'
-        ja: 'Github Agent Secret 値'
-        ko: 'Github Agent Secret 값'
-        ru: 'Значение Github Agent Secret'
-        ms: 'Nilai Github Agent Secret'
-        pt-br: 'Valor do Github Agent Secret'
       required: true
       type: text
     - default: "true"
@@ -95,15 +86,6 @@ additionalProperties:
       envKey: GITHUB_ENABLE_SWITCH
       labelEn: Enable Github (true or false)
       labelZh: 启用Github(true/false)
-      label:
-        en: 'Enable Github (true or false)'
-        zh: '启用Github(true/false)'
-        zh-Hant: '啟用Github(true/false)'
-        ja: 'Github を有効化（true/false）'
-        ko: 'Github 활성화(true/false)'
-        ru: 'Включить Github (true/false)'
-        ms: 'Dayakan Github (true/false)'
-        pt-br: 'Ativar Github (true/false)'
       label:
         en: 'Enable Github (true or false)'
         zh: '启用Github(true/false)'
@@ -129,15 +111,6 @@ additionalProperties:
         ru: 'URL Github'
         ms: 'URL Github'
         pt-br: 'URL do Github'
-      label:
-        en: 'Github URL'
-        zh: 'Github地址'
-        zh-Hant: 'Github 地址'
-        ja: 'Github の URL'
-        ko: 'Github URL 주소'
-        ru: 'URL Github'
-        ms: 'URL Github'
-        pt-br: 'URL do Github'
       required: false
       type: text
     - default: ''
@@ -145,15 +118,6 @@ additionalProperties:
       envKey: WOODPECKER_GITHUB_CLIENT
       labelEn: Github CLIENT Vaule
       labelZh: Github CLIENT 值
-      label:
-        en: 'Github CLIENT Vaule'
-        zh: 'Github CLIENT 值'
-        zh-Hant: 'Github CLIENT 值'
-        ja: 'Github CLIENT 値'
-        ko: 'Github CLIENT 값'
-        ru: 'Значение Github CLIENT'
-        ms: 'Nilai Github CLIENT'
-        pt-br: 'Valor do Github CLIENT'
       label:
         en: 'Github CLIENT Vaule'
         zh: 'Github CLIENT 值'
@@ -179,15 +143,6 @@ additionalProperties:
         ru: 'Значение Github SECRET'
         ms: 'Nilai Github SECRET'
         pt-br: 'Valor do Github SECRET'
-      label:
-        en: 'Github SECRET Vaule'
-        zh: 'Github SECRET 值'
-        zh-Hant: 'Github SECRET 值'
-        ja: 'Github SECRET 値'
-        ko: 'Github SECRET 값'
-        ru: 'Значение Github SECRET'
-        ms: 'Nilai Github SECRET'
-        pt-br: 'Valor do Github SECRET'
       required: false
       type: text
     - default: "false"
@@ -195,15 +150,6 @@ additionalProperties:
       envKey: GITEA_ENABLE_SWITCH
       labelEn: Enable Gitea (true or false)
       labelZh: 启用Gitea(true/false)
-      label:
-        en: 'Enable Gitea (true or false)'
-        zh: '启用Gitea(true/false)'
-        zh-Hant: '啟用Gitea(true/false)'
-        ja: 'Gitea を有効化（true/false）'
-        ko: 'Gitea 활성화(true/false)'
-        ru: 'Включить Gitea (true/false)'
-        ms: 'Dayakan Gitea (true/false)'
-        pt-br: 'Ativar Gitea (true/false)'
       label:
         en: 'Enable Gitea (true or false)'
         zh: '启用Gitea(true/false)'
@@ -229,15 +175,6 @@ additionalProperties:
         ru: 'URL Gitea'
         ms: 'URL Gitea'
         pt-br: 'URL do Gitea'
-      label:
-        en: 'Gitea URL'
-        zh: 'Gitea地址'
-        zh-Hant: 'Gitea 地址'
-        ja: 'Gitea の URL'
-        ko: 'Gitea URL 주소'
-        ru: 'URL Gitea'
-        ms: 'URL Gitea'
-        pt-br: 'URL do Gitea'
       required: false
       type: text
     - default: ''
@@ -245,15 +182,6 @@ additionalProperties:
       envKey: WOODPECKER_GITEA_CLIENT
       labelEn: Gitea CLIENT Vaule
       labelZh: Gitea CLIENT 值
-      label:
-        en: 'Gitea CLIENT Vaule'
-        zh: 'Gitea CLIENT 值'
-        zh-Hant: 'Gitea CLIENT 值'
-        ja: 'Gitea CLIENT 値'
-        ko: 'Gitea CLIENT 값'
-        ru: 'Значение Gitea CLIENT'
-        ms: 'Nilai Gitea CLIENT'
-        pt-br: 'Valor do Gitea CLIENT'
       label:
         en: 'Gitea CLIENT Vaule'
         zh: 'Gitea CLIENT 值'
@@ -279,15 +207,6 @@ additionalProperties:
         ru: 'Значение Gitea SECRET'
         ms: 'Nilai Gitea SECRET'
         pt-br: 'Valor do Gitea SECRET'
-      label:
-        en: 'Gitea SECRET Vaule'
-        zh: 'Gitea SECRET 值'
-        zh-Hant: 'Gitea SECRET 值'
-        ja: 'Gitea SECRET 値'
-        ko: 'Gitea SECRET 값'
-        ru: 'Значение Gitea SECRET'
-        ms: 'Nilai Gitea SECRET'
-        pt-br: 'Valor do Gitea SECRET'
       required: false
       type: text
     - default: "false"
@@ -295,15 +214,6 @@ additionalProperties:
       envKey: GITLAB_ENABLE_SWITCH
       labelEn: Enable GitLab (true or false)
       labelZh: 启用GitLab (true/false)
-      label:
-        en: 'Enable GitLab (true or false)'
-        zh: '启用GitLab (true/false)'
-        zh-Hant: '啟用GitLab (true/false)'
-        ja: 'GitLab を有効化（true/false）'
-        ko: 'GitLab 활성화(true/false)'
-        ru: 'Включить GitLab (true/false)'
-        ms: 'Dayakan GitLab (true/false)'
-        pt-br: 'Ativar GitLab (true/false)'
       label:
         en: 'Enable GitLab (true or false)'
         zh: '启用GitLab (true/false)'
@@ -329,15 +239,6 @@ additionalProperties:
         ru: 'URL GitLab'
         ms: 'URL GitLab'
         pt-br: 'URL do GitLab'
-      label:
-        en: 'GitLab URL'
-        zh: 'GitLab 地址'
-        zh-Hant: 'GitLab 地址'
-        ja: 'GitLab の URL'
-        ko: 'GitLab URL 주소'
-        ru: 'URL GitLab'
-        ms: 'URL GitLab'
-        pt-br: 'URL do GitLab'
       required: false
       type: text
     - default: ''
@@ -345,15 +246,6 @@ additionalProperties:
       envKey: WOODPECKER_GITLAB_CLIENT
       labelEn: GitLab CLIENT Vaule
       labelZh: GitLab CLIENT 值
-      label:
-        en: 'GitLab CLIENT Vaule'
-        zh: 'GitLab CLIENT 值'
-        zh-Hant: 'GitLab CLIENT 值'
-        ja: 'GitLab CLIENT 値'
-        ko: 'GitLab CLIENT 값'
-        ru: 'Значение GitLab CLIENT'
-        ms: 'Nilai GitLab CLIENT'
-        pt-br: 'Valor do GitLab CLIENT'
       label:
         en: 'GitLab CLIENT Vaule'
         zh: 'GitLab CLIENT 值'
@@ -379,15 +271,6 @@ additionalProperties:
         ru: 'Значение GitLab SECRET'
         ms: 'Nilai GitLab SECRET'
         pt-br: 'Valor do GitLab SECRET'
-      label:
-        en: 'GitLab SECRET Vaule'
-        zh: 'GitLab SECRET 值'
-        zh-Hant: 'GitLab SECRET 值'
-        ja: 'GitLab SECRET 値'
-        ko: 'GitLab SECRET 값'
-        ru: 'Значение GitLab SECRET'
-        ms: 'Nilai GitLab SECRET'
-        pt-br: 'Valor do GitLab SECRET'
       required: false
       type: text
     - default: "false"
@@ -395,15 +278,6 @@ additionalProperties:
       envKey: BITBUCKET_ENABLE_SWITCH
       labelEn: Enable Bitbucket (true or false)
       labelZh: 启用 Bitbucket (true/false)
-      label:
-        en: 'Enable Bitbucket (true or false)'
-        zh: '启用 Bitbucket (true/false)'
-        zh-Hant: '啟用 Bitbucket (true/false)'
-        ja: 'Bitbucket を有効化（true/false）'
-        ko: 'Bitbucket 활성화(true/false)'
-        ru: 'Включить Bitbucket (true/false)'
-        ms: 'Dayakan Bitbucket (true/false)'
-        pt-br: 'Ativar Bitbucket (true/false)'
       label:
         en: 'Enable Bitbucket (true or false)'
         zh: '启用 Bitbucket (true/false)'
@@ -429,15 +303,6 @@ additionalProperties:
         ru: 'Значение Bitbucket CLIENT'
         ms: 'Nilai Bitbucket CLIENT'
         pt-br: 'Valor do Bitbucket CLIENT'
-      label:
-        en: 'Bitbucket CLIENT Value'
-        zh: 'Bitbucket CLIENT 值'
-        zh-Hant: 'Bitbucket CLIENT 值'
-        ja: 'Bitbucket CLIENT 値'
-        ko: 'Bitbucket CLIENT 값'
-        ru: 'Значение Bitbucket CLIENT'
-        ms: 'Nilai Bitbucket CLIENT'
-        pt-br: 'Valor do Bitbucket CLIENT'
       required: false
       type: text
     - default: ''
@@ -445,15 +310,6 @@ additionalProperties:
       envKey: WOODPECKER_BITBUCKET_SECRET
       labelEn: Bitbucket SECRET Value
       labelZh: Bitbucket SECRET 值
-      label:
-        en: 'Bitbucket SECRET Value'
-        zh: 'Bitbucket SECRET 值'
-        zh-Hant: 'Bitbucket SECRET 值'
-        ja: 'Bitbucket SECRET 値'
-        ko: 'Bitbucket SECRET 값'
-        ru: 'Значение Bitbucket SECRET'
-        ms: 'Nilai Bitbucket SECRET'
-        pt-br: 'Valor do Bitbucket SECRET'
       label:
         en: 'Bitbucket SECRET Value'
         zh: 'Bitbucket SECRET 值'

--- a/apps/woodpecker/latest/data.yml
+++ b/apps/woodpecker/latest/data.yml
@@ -79,15 +79,6 @@ additionalProperties:
         ru: 'Значение Github Agent Secret'
         ms: 'Nilai Github Agent Secret'
         pt-br: 'Valor do Github Agent Secret'
-      label:
-        en: 'Github Agent Secret Vaule'
-        zh: 'Github Agent Secret 值'
-        zh-Hant: 'Github Agent Secret 值'
-        ja: 'Github Agent Secret 値'
-        ko: 'Github Agent Secret 값'
-        ru: 'Значение Github Agent Secret'
-        ms: 'Nilai Github Agent Secret'
-        pt-br: 'Valor do Github Agent Secret'
       required: true
       type: text
     - default: "true"
@@ -95,15 +86,6 @@ additionalProperties:
       envKey: GITHUB_ENABLE_SWITCH
       labelEn: Enable Github (true or false)
       labelZh: 启用Github(true/false)
-      label:
-        en: 'Enable Github (true or false)'
-        zh: '启用Github(true/false)'
-        zh-Hant: '啟用Github(true/false)'
-        ja: 'Github を有効化（true/false）'
-        ko: 'Github 활성화(true/false)'
-        ru: 'Включить Github (true/false)'
-        ms: 'Dayakan Github (true/false)'
-        pt-br: 'Ativar Github (true/false)'
       label:
         en: 'Enable Github (true or false)'
         zh: '启用Github(true/false)'
@@ -129,15 +111,6 @@ additionalProperties:
         ru: 'URL Github'
         ms: 'URL Github'
         pt-br: 'URL do Github'
-      label:
-        en: 'Github URL'
-        zh: 'Github地址'
-        zh-Hant: 'Github 地址'
-        ja: 'Github の URL'
-        ko: 'Github URL 주소'
-        ru: 'URL Github'
-        ms: 'URL Github'
-        pt-br: 'URL do Github'
       required: false
       type: text
     - default: ''
@@ -145,15 +118,6 @@ additionalProperties:
       envKey: WOODPECKER_GITHUB_CLIENT
       labelEn: Github CLIENT Vaule
       labelZh: Github CLIENT 值
-      label:
-        en: 'Github CLIENT Vaule'
-        zh: 'Github CLIENT 值'
-        zh-Hant: 'Github CLIENT 值'
-        ja: 'Github CLIENT 値'
-        ko: 'Github CLIENT 값'
-        ru: 'Значение Github CLIENT'
-        ms: 'Nilai Github CLIENT'
-        pt-br: 'Valor do Github CLIENT'
       label:
         en: 'Github CLIENT Vaule'
         zh: 'Github CLIENT 值'
@@ -179,15 +143,6 @@ additionalProperties:
         ru: 'Значение Github SECRET'
         ms: 'Nilai Github SECRET'
         pt-br: 'Valor do Github SECRET'
-      label:
-        en: 'Github SECRET Vaule'
-        zh: 'Github SECRET 值'
-        zh-Hant: 'Github SECRET 值'
-        ja: 'Github SECRET 値'
-        ko: 'Github SECRET 값'
-        ru: 'Значение Github SECRET'
-        ms: 'Nilai Github SECRET'
-        pt-br: 'Valor do Github SECRET'
       required: false
       type: text
     - default: "false"
@@ -195,15 +150,6 @@ additionalProperties:
       envKey: GITEA_ENABLE_SWITCH
       labelEn: Enable Gitea (true or false)
       labelZh: 启用Gitea(true/false)
-      label:
-        en: 'Enable Gitea (true or false)'
-        zh: '启用Gitea(true/false)'
-        zh-Hant: '啟用Gitea(true/false)'
-        ja: 'Gitea を有効化（true/false）'
-        ko: 'Gitea 활성화(true/false)'
-        ru: 'Включить Gitea (true/false)'
-        ms: 'Dayakan Gitea (true/false)'
-        pt-br: 'Ativar Gitea (true/false)'
       label:
         en: 'Enable Gitea (true or false)'
         zh: '启用Gitea(true/false)'
@@ -229,15 +175,6 @@ additionalProperties:
         ru: 'URL Gitea'
         ms: 'URL Gitea'
         pt-br: 'URL do Gitea'
-      label:
-        en: 'Gitea URL'
-        zh: 'Gitea地址'
-        zh-Hant: 'Gitea 地址'
-        ja: 'Gitea の URL'
-        ko: 'Gitea URL 주소'
-        ru: 'URL Gitea'
-        ms: 'URL Gitea'
-        pt-br: 'URL do Gitea'
       required: false
       type: text
     - default: ''
@@ -245,15 +182,6 @@ additionalProperties:
       envKey: WOODPECKER_GITEA_CLIENT
       labelEn: Gitea CLIENT Vaule
       labelZh: Gitea CLIENT 值
-      label:
-        en: 'Gitea CLIENT Vaule'
-        zh: 'Gitea CLIENT 值'
-        zh-Hant: 'Gitea CLIENT 值'
-        ja: 'Gitea CLIENT 値'
-        ko: 'Gitea CLIENT 값'
-        ru: 'Значение Gitea CLIENT'
-        ms: 'Nilai Gitea CLIENT'
-        pt-br: 'Valor do Gitea CLIENT'
       label:
         en: 'Gitea CLIENT Vaule'
         zh: 'Gitea CLIENT 值'
@@ -279,15 +207,6 @@ additionalProperties:
         ru: 'Значение Gitea SECRET'
         ms: 'Nilai Gitea SECRET'
         pt-br: 'Valor do Gitea SECRET'
-      label:
-        en: 'Gitea SECRET Vaule'
-        zh: 'Gitea SECRET 值'
-        zh-Hant: 'Gitea SECRET 值'
-        ja: 'Gitea SECRET 値'
-        ko: 'Gitea SECRET 값'
-        ru: 'Значение Gitea SECRET'
-        ms: 'Nilai Gitea SECRET'
-        pt-br: 'Valor do Gitea SECRET'
       required: false
       type: text
     - default: "false"
@@ -295,15 +214,6 @@ additionalProperties:
       envKey: GITLAB_ENABLE_SWITCH
       labelEn: Enable GitLab (true or false)
       labelZh: 启用GitLab (true/false)
-      label:
-        en: 'Enable GitLab (true or false)'
-        zh: '启用GitLab (true/false)'
-        zh-Hant: '啟用GitLab (true/false)'
-        ja: 'GitLab を有効化（true/false）'
-        ko: 'GitLab 활성화(true/false)'
-        ru: 'Включить GitLab (true/false)'
-        ms: 'Dayakan GitLab (true/false)'
-        pt-br: 'Ativar GitLab (true/false)'
       label:
         en: 'Enable GitLab (true or false)'
         zh: '启用GitLab (true/false)'
@@ -329,15 +239,6 @@ additionalProperties:
         ru: 'URL GitLab'
         ms: 'URL GitLab'
         pt-br: 'URL do GitLab'
-      label:
-        en: 'GitLab URL'
-        zh: 'GitLab 地址'
-        zh-Hant: 'GitLab 地址'
-        ja: 'GitLab の URL'
-        ko: 'GitLab URL 주소'
-        ru: 'URL GitLab'
-        ms: 'URL GitLab'
-        pt-br: 'URL do GitLab'
       required: false
       type: text
     - default: ''
@@ -345,15 +246,6 @@ additionalProperties:
       envKey: WOODPECKER_GITLAB_CLIENT
       labelEn: GitLab CLIENT Vaule
       labelZh: GitLab CLIENT 值
-      label:
-        en: 'GitLab CLIENT Vaule'
-        zh: 'GitLab CLIENT 值'
-        zh-Hant: 'GitLab CLIENT 值'
-        ja: 'GitLab CLIENT 値'
-        ko: 'GitLab CLIENT 값'
-        ru: 'Значение GitLab CLIENT'
-        ms: 'Nilai GitLab CLIENT'
-        pt-br: 'Valor do GitLab CLIENT'
       label:
         en: 'GitLab CLIENT Vaule'
         zh: 'GitLab CLIENT 值'
@@ -379,15 +271,6 @@ additionalProperties:
         ru: 'Значение GitLab SECRET'
         ms: 'Nilai GitLab SECRET'
         pt-br: 'Valor do GitLab SECRET'
-      label:
-        en: 'GitLab SECRET Vaule'
-        zh: 'GitLab SECRET 值'
-        zh-Hant: 'GitLab SECRET 值'
-        ja: 'GitLab SECRET 値'
-        ko: 'GitLab SECRET 값'
-        ru: 'Значение GitLab SECRET'
-        ms: 'Nilai GitLab SECRET'
-        pt-br: 'Valor do GitLab SECRET'
       required: false
       type: text
     - default: "false"
@@ -395,15 +278,6 @@ additionalProperties:
       envKey: BITBUCKET_ENABLE_SWITCH
       labelEn: Enable Bitbucket (true or false)
       labelZh: 启用 Bitbucket (true/false)
-      label:
-        en: 'Enable Bitbucket (true or false)'
-        zh: '启用 Bitbucket (true/false)'
-        zh-Hant: '啟用 Bitbucket (true/false)'
-        ja: 'Bitbucket を有効化（true/false）'
-        ko: 'Bitbucket 활성화(true/false)'
-        ru: 'Включить Bitbucket (true/false)'
-        ms: 'Dayakan Bitbucket (true/false)'
-        pt-br: 'Ativar Bitbucket (true/false)'
       label:
         en: 'Enable Bitbucket (true or false)'
         zh: '启用 Bitbucket (true/false)'
@@ -429,15 +303,6 @@ additionalProperties:
         ru: 'Значение Bitbucket CLIENT'
         ms: 'Nilai Bitbucket CLIENT'
         pt-br: 'Valor do Bitbucket CLIENT'
-      label:
-        en: 'Bitbucket CLIENT Value'
-        zh: 'Bitbucket CLIENT 值'
-        zh-Hant: 'Bitbucket CLIENT 值'
-        ja: 'Bitbucket CLIENT 値'
-        ko: 'Bitbucket CLIENT 값'
-        ru: 'Значение Bitbucket CLIENT'
-        ms: 'Nilai Bitbucket CLIENT'
-        pt-br: 'Valor do Bitbucket CLIENT'
       required: false
       type: text
     - default: ''
@@ -445,15 +310,6 @@ additionalProperties:
       envKey: WOODPECKER_BITBUCKET_SECRET
       labelEn: Bitbucket SECRET Value
       labelZh: Bitbucket SECRET 值
-      label:
-        en: 'Bitbucket SECRET Value'
-        zh: 'Bitbucket SECRET 值'
-        zh-Hant: 'Bitbucket SECRET 值'
-        ja: 'Bitbucket SECRET 値'
-        ko: 'Bitbucket SECRET 값'
-        ru: 'Значение Bitbucket SECRET'
-        ms: 'Nilai Bitbucket SECRET'
-        pt-br: 'Valor do Bitbucket SECRET'
       label:
         en: 'Bitbucket SECRET Value'
         zh: 'Bitbucket SECRET 值'


### PR DESCRIPTION
## Summary
- remove invalid localized `label:` maps from affected version `data.yml` files
- keep `labelEn` / `labelZh` so 1Panel can parse values as strings
- cover autoheal/openclaw/plex/radarr/sonarr/wewe-rss/woodpecker import failures

## Validation
- `validate-v2.sh --strict-store` PASS for autoheal/openclaw/plex/radarr/sonarr/wewe-rss/woodpecker
- new test container: `moelin/1panel:global-v1.10.34-lts`
- host port: `10089`
- base_dir: `/home/node/1panel-test-10089`
- `1panel app init` succeeded for all 10 affected versions

[openclaw]