### PR TITLE
fix(autoheal): dedupe invalid localized label entries for latest

### DIFF
--- a/apps/autoheal/latest/data.yml
+++ b/apps/autoheal/latest/data.yml
@@ -1,24 +1,18 @@
 additionalProperties:
   formFields:
-    - default: 'AUTOHEAL_CONTAINER_LABEL=all'
+    - default: "AUTOHEAL_CONTAINER_LABEL=all"
       edit: true
       envKey: ENV1
       labelEn: Environmental parameters
       labelZh: 环境参数
       label:
-        en: 'Environmental parameters'
-        zh: '环境参数'
-        zh-Hant: '環境參數'
-        ja: '環境パラメータ'
-        ko: '환경 매개변수'
-        ru: 'Параметры среды'
-        ms: 'Parameter persekitaran'
-        pt-br: 'Parâmetros de ambiente'
-        zh-Hant: '環境參數'
-        ja: '環境パラメータ'
-        ko: '환경 매개변수'
-        ru: 'Параметры среды'
-        ms: 'Parameter persekitaran'
-        pt-br: 'Parâmetros de ambiente'
+        en: "Environmental parameters"
+        zh: "环境参数"
+        zh-Hant: "環境參數"
+        ja: "環境パラメータ"
+        ko: "환경 매개변수"
+        ru: "Параметры среды"
+        ms: "Parameter persekitaran"
+        pt-br: "Parâmetros de ambiente"
       required: true
       type: text


### PR DESCRIPTION
[openclaw]

Fix autoheal/latest/data.yml duplicated localized label keys that can break 1Panel YAML parsing during local app sync.

- dedupe repeated language keys under formFields[].label
- keep strict i18n-compatible label structure
- validated with validate-v2.sh --strict-store
