### PR TITLE
fix: 锁定metapi数字镜像版本

### DIFF
--- a/apps/metapi/1.3.0/docker-compose.yml
+++ b/apps/metapi/1.3.0/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   metapi:
-    image: "1467078763/metapi:latest"
+    image: "1467078763/metapi:v1.3.0"
     ports:
       - "${PANEL_APP_PORT_HTTP}:4000"
     environment:

--- a/apps/metapi/latest/docker-compose.yml
+++ b/apps/metapi/latest/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   metapi:
-    image: "1467078763/metapi:latest"
+    image: "1467078763/metapi:v1.3.0"
     ports:
       - "${PANEL_APP_PORT_HTTP}:4000"
     environment:


### PR DESCRIPTION
## Summary
- replace `1467078763/metapi:latest` with `1467078763/metapi:v1.3.0` in both `apps/metapi/1.3.0` and `apps/metapi/latest`
- keep the app version directory aligned with an explicit numeric upstream image tag

## Validation
- `validate-v2.sh --dir apps/metapi --strict-store` -> PASS

[openclaw] generated PR