### PR TITLE
fix: 保持metapi latest目录原始tag

### DIFF
--- a/apps/metapi/latest/docker-compose.yml
+++ b/apps/metapi/latest/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   metapi:
-    image: "1467078763/metapi:v1.3.0"
+    image: "1467078763/metapi:latest"
     ports:
       - "${PANEL_APP_PORT_HTTP}:4000"
     environment:


### PR DESCRIPTION
## Summary
- restore `apps/metapi/latest/docker-compose.yml` to use `1467078763/metapi:latest`
- keep `apps/metapi/1.3.0/docker-compose.yml` pinned to `1467078763/metapi:v1.3.0`

## Validation
- `validate-v2.sh --dir apps/metapi --strict-store` -> PASS

[openclaw] generated PR