### PR TITLE
修复metapi安装问题

### DIFF
--- a/apps/metapi/1.3.0/.env.sample
+++ b/apps/metapi/1.3.0/.env.sample
@@ -1,4 +1,4 @@
-APP_DATA_DIR="./data"
+APP_DATA_DIR="data"
 AUTH_TOKEN=""
 BALANCE_REFRESH_CRON="0 * * * *"
 CHECKIN_CRON="0 8 * * *"

--- a/apps/metapi/1.3.0/data.yml
+++ b/apps/metapi/1.3.0/data.yml
@@ -17,20 +17,20 @@ additionalProperties:
       required: true
       rule: paramPort
       type: number
-    - default: ./data
+    - default: data
       envKey: APP_DATA_DIR
       edit: true
-      labelEn: Data directory
-      labelZh: 数据目录
+      labelEn: Data volume name
+      labelZh: 数据卷名
       label:
-        en: Data directory
-        zh: 数据目录
-        zh-Hant: 資料目錄
-        ja: データディレクトリ
-        ko: 데이터 디렉터리
-        ru: Каталог данных
-        ms: Direktori data
-        pt-br: Diretório de dados
+        en: Data volume name
+        zh: 数据卷名
+        zh-Hant: 資料卷名稱
+        ja: データボリューム名
+        ko: 데이터 볼륨 이름
+        ru: Имя тома данных
+        ms: Nama volum data
+        pt-br: Nome do volume de dados
       required: true
       rule: paramCommon
       type: text

--- a/apps/metapi/1.3.0/docker-compose.yml
+++ b/apps/metapi/1.3.0/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - "DATA_DIR=/app/data"
       - "TZ=${TZ}"
     volumes:
-      - "${APP_DATA_DIR}:/app/data"
+      - "${APP_DATA_DIR:-data}:/app/data"
     restart: unless-stopped
     labels:
       createdBy: "Apps"

--- a/apps/metapi/1.3.0/scripts/init.sh
+++ b/apps/metapi/1.3.0/scripts/init.sh
@@ -1,4 +1,13 @@
 #!/bin/bash
 set -euo pipefail
 
-mkdir -p "${APP_DATA_DIR:-./data}"
+APP_DATA_DIR_VALUE="${APP_DATA_DIR:-data}"
+
+# Only create local directories for bind-mount style paths.
+case "${APP_DATA_DIR_VALUE}" in
+  /*|./*|../*)
+    mkdir -p "${APP_DATA_DIR_VALUE}"
+    ;;
+  *)
+    ;;
+esac

--- a/apps/metapi/latest/.env.sample
+++ b/apps/metapi/latest/.env.sample
@@ -1,4 +1,4 @@
-APP_DATA_DIR="./data"
+APP_DATA_DIR="data"
 AUTH_TOKEN=""
 BALANCE_REFRESH_CRON="0 * * * *"
 CHECKIN_CRON="0 8 * * *"

--- a/apps/metapi/latest/data.yml
+++ b/apps/metapi/latest/data.yml
@@ -17,20 +17,20 @@ additionalProperties:
       required: true
       rule: paramPort
       type: number
-    - default: ./data
+    - default: data
       envKey: APP_DATA_DIR
       edit: true
-      labelEn: Data directory
-      labelZh: 数据目录
+      labelEn: Data volume name
+      labelZh: 数据卷名
       label:
-        en: Data directory
-        zh: 数据目录
-        zh-Hant: 資料目錄
-        ja: データディレクトリ
-        ko: 데이터 디렉터리
-        ru: Каталог данных
-        ms: Direktori data
-        pt-br: Diretório de dados
+        en: Data volume name
+        zh: 数据卷名
+        zh-Hant: 資料卷名稱
+        ja: データボリューム名
+        ko: 데이터 볼륨 이름
+        ru: Имя тома данных
+        ms: Nama volum data
+        pt-br: Nome do volume de dados
       required: true
       rule: paramCommon
       type: text

--- a/apps/metapi/latest/docker-compose.yml
+++ b/apps/metapi/latest/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - "DATA_DIR=/app/data"
       - "TZ=${TZ}"
     volumes:
-      - "${APP_DATA_DIR}:/app/data"
+      - "${APP_DATA_DIR:-data}:/app/data"
     restart: unless-stopped
     labels:
       createdBy: "Apps"

--- a/apps/metapi/latest/scripts/init.sh
+++ b/apps/metapi/latest/scripts/init.sh
@@ -1,4 +1,13 @@
 #!/bin/bash
 set -euo pipefail
 
-mkdir -p "${APP_DATA_DIR:-./data}"
+APP_DATA_DIR_VALUE="${APP_DATA_DIR:-data}"
+
+# Only create local directories for bind-mount style paths.
+case "${APP_DATA_DIR_VALUE}" in
+  /*|./*|../*)
+    mkdir -p "${APP_DATA_DIR_VALUE}"
+    ;;
+  *)
+    ;;
+esac


### PR DESCRIPTION
修复metapi安装问题
表单规则是 paramCommon（不允许 /），导致配置自相矛盾报错