### PR TITLE
fix(metapi): remove rule fields except port from data.yml

### DIFF
--- a/apps/metapi/1.3.0/data.yml
+++ b/apps/metapi/1.3.0/data.yml
@@ -32,7 +32,6 @@ additionalProperties:
         ms: Direktori data
         pt-br: Diretório de dados
       required: true
-      rule: paramCommon
       type: text
     - default: ""
       envKey: AUTH_TOKEN
@@ -81,7 +80,6 @@ additionalProperties:
         ms: Cron daftar masuk
         pt-br: Cron de check-in
       required: false
-      rule: paramCommon
       type: text
     - default: "0 * * * *"
       envKey: BALANCE_REFRESH_CRON
@@ -98,7 +96,6 @@ additionalProperties:
         ms: Cron segar semula baki
         pt-br: Cron de atualização de saldo
       required: false
-      rule: paramCommon
       type: text
     - default: Asia/Shanghai
       envKey: TZ

--- a/apps/metapi/latest/data.yml
+++ b/apps/metapi/latest/data.yml
@@ -32,7 +32,6 @@ additionalProperties:
         ms: Direktori data
         pt-br: Diretório de dados
       required: true
-      rule: paramCommon
       type: text
     - default: ""
       envKey: AUTH_TOKEN
@@ -81,7 +80,6 @@ additionalProperties:
         ms: Cron daftar masuk
         pt-br: Cron de check-in
       required: false
-      rule: paramCommon
       type: text
     - default: "0 * * * *"
       envKey: BALANCE_REFRESH_CRON
@@ -98,7 +96,6 @@ additionalProperties:
         ms: Cron segar semula baki
         pt-br: Cron de atualização de saldo
       required: false
-      rule: paramCommon
       type: text
     - default: Asia/Shanghai
       envKey: TZ


### PR DESCRIPTION
## Summary
- Remove `paramCommon` rule from non-port formFields in metapi data.yml
- Keep `paramPort` rule for `PANEL_APP_PORT_HTTP` (port field)

## Changes
- `apps/metapi/1.3.0/data.yml`: Removed `rule: paramCommon` from APP_DATA_DIR, CHECKIN_CRON, BALANCE_REFRESH_CRON
- `apps/metapi/latest/data.yml`: Same changes as above

## Reason
The `paramCommon` rule is not needed for these fields. Only port fields should have the `paramPort` rule for port occupation check during installation.