### PR TITLE
Fix renovate reconcile workflow dispatch

### DIFF
--- a/.github/workflows/renovate-automerge-reconcile.yml
+++ b/.github/workflows/renovate-automerge-reconcile.yml
@@ -42,7 +42,6 @@ jobs:
                 | select(.isDraft | not)
                 | select(.baseRefName == "localApps")
                 | select(([.labels[].name] | index("renovate-auto")) | not)
-                | select(([.labels[].name] | index("renovate-auto-reconcile")) | not)
                 | .number'
           )
 
@@ -110,7 +109,7 @@ jobs:
             echo 'EOF'
           } >> "$GITHUB_OUTPUT"
 
-      - name: Dispatch automerge workflow for reconciled PRs
+      - name: Dispatch automerge workflow for eligible PRs
         if: steps.scan.outputs.pr_numbers != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUBTOKEN }}
@@ -118,11 +117,10 @@ jobs:
         run: |
           while IFS= read -r pr_number; do
             [ -n "$pr_number" ] || continue
-            gh pr edit "$pr_number" \
+            echo "Dispatching renovate-automerge.yml for PR #$pr_number on localApps"
+            gh workflow run renovate-automerge.yml \
               --repo "$REPO" \
-              --add-label renovate-auto-reconcile
-            gh workflow run .github/workflows/renovate-automerge.yml \
-              --repo "$REPO" \
+              --ref localApps \
               -f pr_number="$pr_number"
             sleep 2
           done <<< "${{ steps.scan.outputs.pr_numbers }}"


### PR DESCRIPTION
## Summary
- remove the nonexistent `renovate-auto-reconcile` dependency from reconcile
- dispatch `renovate-automerge.yml` directly for eligible PRs
- harden workflow dispatch with explicit `--ref localApps`

## Validation
- YAML parse check passed
- workflow shell blocks passed syntax validation
- `git diff --check` passed
- goal-fit, QA, code-quality, security, and context reviews passed
