### PR TITLE
Add bilingual issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/app_request.yml
+++ b/.github/ISSUE_TEMPLATE/app_request.yml
@@ -1,0 +1,121 @@
+name: 应用适配需求 / App Request
+description: 申请为 okxlin/appstore 新增或适配一个 1Panel v2 应用 / Request a new or adapted 1Panel v2 app for okxlin/appstore.
+title: "[App Request / 应用适配] "
+labels: ["type/request", "area/app-adaptation", "status/needs-info", "triage/needs-review"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        请尽量提供官方来源和可复现 Docker 信息 / Please provide official source and reproducible Docker details. 信息完整后，维护者会先交给 1panel-app-adapter 适配，再用 1panel-test-targets 做 1Panel v2 部署测试 / Once complete, the maintainer will hand it to 1panel-app-adapter, then use 1panel-test-targets for 1Panel v2 deployment testing.
+  - type: input
+    id: app-name
+    attributes:
+      label: 应用名称 / App name
+      description: 填写应用官方名称 / Enter the official app name.
+      placeholder: Vaultwarden
+    validations:
+      required: true
+  - type: input
+    id: app-key
+    attributes:
+      label: 建议 app key / Suggested app key
+      description: 可选。建议使用小写字母、数字和连字符 / Optional. Use lowercase letters, numbers, and hyphens.
+      placeholder: vaultwarden
+    validations:
+      required: false
+  - type: textarea
+    id: official-source
+    attributes:
+      label: 官方来源 / Official source
+      description: 官方网站、官方仓库、官方文档。请不要只贴第三方教程 / Official website, repository, or documentation. Do not submit only third-party tutorials.
+      placeholder: |
+        官方网站 / Official website:
+        官方仓库 / Official repository:
+        官方文档 / Official documentation:
+    validations:
+      required: true
+  - type: textarea
+    id: docker-source
+    attributes:
+      label: Docker 来源 / Docker source
+      description: 官方 Docker 镜像、官方 compose 文档或官方 compose 文件链接 / Official Docker image, compose docs, or compose file link.
+      placeholder: |
+        官方 Docker 镜像 / Official Docker image:
+        官方 docker-compose.yml / compose 文档 / Official compose docs:
+        目标版本或 release channel / Target version or release channel:
+    validations:
+      required: true
+  - type: input
+    id: ports
+    attributes:
+      label: 默认端口 / Default ports
+      placeholder: 80, 443, 8080
+    validations:
+      required: true
+  - type: textarea
+    id: volumes
+    attributes:
+      label: 数据目录 / volumes / Data directories / volumes
+      placeholder: /data, /config, ./data:/data
+    validations:
+      required: true
+  - type: dropdown
+    id: dependencies
+    attributes:
+      label: 依赖服务 / Dependencies
+      multiple: true
+      options:
+        - 无 / None
+        - MySQL
+        - PostgreSQL
+        - MariaDB
+        - Redis
+        - MinIO
+        - 其他 / Other
+    validations:
+      required: true
+  - type: dropdown
+    id: permissions
+    attributes:
+      label: 特殊权限 / Special permissions
+      multiple: true
+      options:
+        - 无 / None
+        - host network
+        - privileged
+        - Docker socket
+        - GPU / NVIDIA
+        - /dev/dri
+        - 其他 / Other
+    validations:
+      required: true
+  - type: dropdown
+    id: architectures
+    attributes:
+      label: 支持架构 / Supported architectures
+      multiple: true
+      options:
+        - amd64
+        - arm64
+        - arm/v7
+        - 不确定 / Unsure
+    validations:
+      required: true
+  - type: textarea
+    id: test-notes
+    attributes:
+      label: 1Panel 测试信息 / 1Panel test notes
+      description: 如果已经手动部署过，请填写版本、环境、结果和注意事项 / If you have already deployed it manually, include version, environment, result, and notes.
+      placeholder: |
+        1Panel 版本 / 1Panel version:
+        是否手动部署成功 / Manual deployment succeeded:
+        失败日志或注意事项 / Failure logs or notes:
+    validations:
+      required: false
+  - type: checkboxes
+    id: confirmation
+    attributes:
+      label: 提交前确认 / Confirmation
+      options:
+        - label: 我已尽量提供官方来源和 Docker 来源，且未提交密码、token 或私有日志 / I provided the best available official and Docker sources, and I did not submit passwords, tokens, or private logs.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 安全敏感问题 / Sensitive security report
+    url: https://github.com/okxlin/appstore/security/advisories/new
+    about: 请不要在公开 issue 中提交 token、密码、私有日志、完整 exploit 或生产环境敏感信息 / Do not submit tokens, passwords, private logs, full exploits, or production-sensitive data in a public issue.

--- a/.github/ISSUE_TEMPLATE/maintenance_update.yml
+++ b/.github/ISSUE_TEMPLATE/maintenance_update.yml
@@ -1,0 +1,55 @@
+name: 维护更新 / Maintenance Update
+description: 请求版本更新、镜像更新、依赖更新、替换、下架或清理 / Request version, image, dependency, replacement, removal, or cleanup maintenance.
+title: "[Maintenance / 维护更新] "
+labels: ["type/maintenance", "area/app-adaptation", "status/needs-info", "triage/needs-review"]
+body:
+  - type: input
+    id: app-key
+    attributes:
+      label: 受影响 app key / Affected app key
+      placeholder: alist
+    validations:
+      required: true
+  - type: dropdown
+    id: update-type
+    attributes:
+      label: 维护类型 / Maintenance type
+      options:
+        - 版本更新 / Version update
+        - 镜像更新 / Image update
+        - 依赖更新 / Dependency update
+        - 配置清理 / Config cleanup
+        - 替换应用 / App replacement
+        - 下架/删除 / Removal
+        - 其他 / Other
+    validations:
+      required: true
+  - type: input
+    id: current-version
+    attributes:
+      label: 当前版本 / 镜像 / Current version or image
+    validations:
+      required: false
+  - type: input
+    id: target-version
+    attributes:
+      label: 目标版本 / 镜像 / Target version or image
+    validations:
+      required: true
+  - type: textarea
+    id: official-release
+    attributes:
+      label: 官方 release / changelog / 镜像来源 / Official release, changelog, or image source
+      placeholder: |
+        官方 release / Official release:
+        官方镜像 / Official image:
+        升级说明 / Upgrade notes:
+    validations:
+      required: true
+  - type: textarea
+    id: migration-notes
+    attributes:
+      label: 迁移或兼容性说明 / Migration or compatibility notes
+      description: 包括数据迁移、环境变量变化、依赖服务变化、破坏性变更 / Include data migration, env changes, dependency changes, and breaking changes.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/metadata_bug.yml
+++ b/.github/ISSUE_TEMPLATE/metadata_bug.yml
@@ -1,0 +1,49 @@
+name: 问题反馈：元数据/本地应用识别 / Metadata Bug
+description: 反馈 data.yml、docker-compose.yml、表单变量、图标、README、i18n 或本地应用识别问题 / Report data.yml, docker-compose.yml, form/env, icon, README, i18n, or local-app recognition issues.
+title: "[Metadata Bug / 元数据问题] "
+labels: ["type/bug", "area/metadata", "status/needs-info", "triage/needs-review"]
+body:
+  - type: input
+    id: app-key
+    attributes:
+      label: 受影响 app key / Affected app key
+      placeholder: alist
+    validations:
+      required: true
+  - type: dropdown
+    id: target
+    attributes:
+      label: 涉及文件或字段 / Affected file or field
+      multiple: true
+      options:
+        - data.yml
+        - docker-compose.yml
+        - formFields / env
+        - logo.png
+        - README
+        - i18n
+        - 本地应用识别 / Local app recognition
+        - 其他 / Other
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: 当前错误现象或实际内容 / Current wrong content or symptom
+      description: 粘贴相关片段即可，不需要运行日志，除非它也导致安装/运行失败 / Paste the relevant snippet only. Runtime logs are not needed unless this also causes install/runtime failure.
+      render: yaml
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: 期望结果或建议修正方向 / Expected result or suggested correction
+    validations:
+      required: true
+  - type: textarea
+    id: notes
+    attributes:
+      label: 补充说明 / Additional context
+      description: 如果该问题也导致安装/运行失败，请说明失败阶段并附脱敏日志 / If this also causes install/runtime failure, include the failing stage and sanitized logs.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,28 @@
+name: 使用咨询 / Question
+description: 询问仓库使用、应用安装方式或不确定是否为缺陷的问题 / Ask about repository usage, app installation, or unclear issues that may not be defects.
+title: "[Question / 咨询] "
+labels: ["type/question", "status/needs-info", "triage/needs-review"]
+body:
+  - type: textarea
+    id: question
+    attributes:
+      label: 你的问题 / Your question
+      description: 请说明你想做什么、已经尝试过什么、卡在哪里 / Explain what you want to do, what you tried, and where you got stuck.
+      placeholder: 我想... / I want to...
+    validations:
+      required: true
+  - type: input
+    id: related-app
+    attributes:
+      label: 相关 app key / Related app key
+      description: 如果和某个应用有关，请填写 / Fill this in if the question is related to a specific app.
+      placeholder: alist
+    validations:
+      required: false
+  - type: textarea
+    id: context
+    attributes:
+      label: 补充上下文 / Additional context
+      description: 如果你认为这是应用包缺陷，请补充 1Panel 版本、失败阶段、复现步骤和脱敏日志 / If you think this is an app package defect, include 1Panel version, failure stage, reproduction steps, and sanitized logs.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/runtime_bug.yml
+++ b/.github/ISSUE_TEMPLATE/runtime_bug.yml
@@ -1,0 +1,96 @@
+name: 问题反馈：安装/运行 / Runtime Bug
+description: 反馈安装、启动、访问、重启、卸载、同步或更新失败 / Report install, start, access, restart, uninstall, sync, or update failures.
+title: "[Runtime Bug / 运行问题] "
+labels: ["type/bug", "area/runtime-test", "status/needs-info", "triage/needs-review"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        请先移除 token、密码、真实域名、私有地址等敏感内容 / Remove tokens, passwords, real domains, private addresses, and other sensitive data first. 维护者会尽量用 1Panel v2 测试目标复现 / Maintainers will try to reproduce with a 1Panel v2 test target.
+  - type: input
+    id: app-key
+    attributes:
+      label: 受影响 app key / Affected app key
+      placeholder: alist
+    validations:
+      required: true
+  - type: input
+    id: app-version
+    attributes:
+      label: 应用版本 / App version
+      placeholder: latest / 3.44.0
+    validations:
+      required: true
+  - type: input
+    id: panel-version
+    attributes:
+      label: 1Panel 版本 / 1Panel version
+      placeholder: v2.x.x
+    validations:
+      required: true
+  - type: input
+    id: environment
+    attributes:
+      label: 系统和架构 / OS and architecture
+      placeholder: Ubuntu 22.04 amd64 / Debian arm64
+    validations:
+      required: true
+  - type: dropdown
+    id: failure-stage
+    attributes:
+      label: 失败阶段 / Failure stage
+      options:
+        - 安装 / Install
+        - 启动 / Start
+        - 访问 / Access
+        - 重启 / Restart
+        - 卸载 / Uninstall
+        - 更新 / Update
+        - 本地应用同步 / Local app sync
+        - 其他 / Other
+    validations:
+      required: true
+  - type: textarea
+    id: repro-steps
+    attributes:
+      label: 复现步骤 / Reproduction steps
+      placeholder: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: 期望结果 / Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: 实际结果 / Actual behavior
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: 脱敏错误日志 / Sanitized error logs
+      description: 请删除密码、token、真实域名、私有地址 / Remove passwords, tokens, real domains, and private addresses.
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: install-params
+    attributes:
+      label: 安装参数 / Install parameters
+      description: 填写会影响运行的端口、路径、依赖服务选择等 / Include ports, paths, dependency selections, and other values that affect runtime.
+    validations:
+      required: false
+  - type: checkboxes
+    id: confirmation
+    attributes:
+      label: 提交前确认 / Confirmation
+      options:
+        - label: 我已移除敏感信息，并提供了可复现步骤 / I removed sensitive data and provided reproducible steps.
+          required: true

--- a/.github/ISSUE_TEMPLATE/security_source_review.yml
+++ b/.github/ISSUE_TEMPLATE/security_source_review.yml
@@ -1,0 +1,54 @@
+name: 安全 / 来源可信度问题 / Security or Source Trust
+description: 反馈 CVE、可疑镜像、危险权限、来源不可信或供应链风险 / Report CVEs, suspicious images, dangerous permissions, untrusted sources, or supply-chain risk.
+title: "[Security / 安全] "
+labels: ["type/security", "status/blocked-security", "triage/needs-review"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        请不要在公开 issue 中粘贴 token、密码、私有地址、完整 exploit 或生产环境日志 / Do not paste tokens, passwords, private addresses, full exploits, or production logs in a public issue. 涉及敏感漏洞或凭据泄露时，请改用 GitHub Security Advisory / Use GitHub Security Advisory for sensitive vulnerabilities or credential leaks.
+  - type: input
+    id: app-key
+    attributes:
+      label: 受影响 app key 或镜像 / Affected app key or image
+      placeholder: app-key / image:tag
+    validations:
+      required: true
+  - type: dropdown
+    id: security-type
+    attributes:
+      label: 问题类型 / Issue type
+      multiple: true
+      options:
+        - CVE / 漏洞
+        - 可疑镜像来源 / Suspicious image source
+        - privileged
+        - host network
+        - Docker socket
+        - GPU / /dev/dri 权限
+        - 泄露敏感信息 / Sensitive data leak
+        - 其他 / Other
+    validations:
+      required: true
+  - type: textarea
+    id: public-evidence
+    attributes:
+      label: 可公开证据 / Public evidence
+      description: 只贴可公开链接、CVE 编号、镜像来源说明或脱敏片段 / Only include public links, CVE IDs, image source notes, or sanitized snippets.
+      placeholder: CVE-xxxx-xxxx / 官方公告 / 镜像仓库链接
+    validations:
+      required: true
+  - type: textarea
+    id: maintainer-action
+    attributes:
+      label: 建议维护动作 / Suggested maintainer action
+      placeholder: 暂停适配 / 替换镜像 / 增加 README 风险说明 / 关闭需求 / pause adaptation / replace image / add README warning / close request
+    validations:
+      required: false
+  - type: checkboxes
+    id: confirmation
+    attributes:
+      label: 提交前确认 / Confirmation
+      options:
+        - label: 我没有在公开 issue 中提交敏感凭据、私有日志或完整 exploit / I did not submit sensitive credentials, private logs, or full exploit details in this public issue.
+          required: true


### PR DESCRIPTION
## Summary\n- Add categorized bilingual GitHub Issue Forms for app requests, runtime bugs, metadata bugs, maintenance updates, questions, and security/source review\n- Disable blank issues for normal contributors so reports include maintainer-ready fields\n\n## Maintenance note\nThis PR was prepared by non-human automated maintenance under okxlin authorization.\n\n## Verification\n- Parsed all .github/ISSUE_TEMPLATE/*.yml with PyYAML\n- Created/verified triage labels separately via GitHub CLI\n\nNo app package changes are included in this PR.