### PR TITLE
Fix SafeLine runtime dependencies

### DIFF
--- a/apps/safeline/latest/docker-compose.yml
+++ b/apps/safeline/latest/docker-compose.yml
@@ -59,7 +59,9 @@ services:
     - ${SAFELINE_DIR}/resources/sock:/app/sock
     environment:
     - TCD_MGT_API=https://${SUBNET_PREFIX}.234:1443/api/open/publish/server
+    - TCD_SNSERVER=${SUBNET_PREFIX}.235:8000
     - SNSERVER_ADDR=${SUBNET_PREFIX}.235:8000
+    - CHAOS_ADDR=${SUBNET_PREFIX}.240
     ulimits:
       nofile: 131072
     network_mode: host
@@ -78,6 +80,7 @@ services:
       - ${SAFELINE_DIR}/resources/luigi:/app/data
     environment:
       - MGT_IP=${SUBNET_PREFIX}.234
+      - LUIGI_PG=postgres://safeline-ce:${POSTGRES_PASSWORD}@safeline-pg/safeline-ce?sslmode=disable
     logging:
       options:
         max-size: "100m"
@@ -134,6 +137,8 @@ services:
       options:
         max-size: "100m"
         max-file: "5"
+    environment:
+      - DB_ADDR=postgres://safeline-ce:${POSTGRES_PASSWORD}@safeline-pg/safeline-ce?sslmode=disable
     volumes:
       - ${SAFELINE_DIR}/resources/sock:/app/sock
       - ${SAFELINE_DIR}/resources/chaos:/app/chaos

--- a/apps/safeline/newnet-latest/data.yml
+++ b/apps/safeline/newnet-latest/data.yml
@@ -50,7 +50,7 @@ additionalProperties:
         pt-br: 'Pasta de armazenamento de dados'
       required: true
       type: text
-    - default: 169.254.0
+    - default: 192.168.255
       edit: true
       envKey: SUBNET_PREFIX
       labelEn: New docker network subnet prefix

--- a/apps/safeline/newnet-latest/docker-compose.yml
+++ b/apps/safeline/newnet-latest/docker-compose.yml
@@ -61,7 +61,9 @@ services:
     - ${SAFELINE_DIR}/resources/sock:/app/sock
     environment:
     - TCD_MGT_API=https://${SUBNET_PREFIX}.4:1443/api/open/publish/server
+    - TCD_SNSERVER=${SUBNET_PREFIX}.5:8000
     - SNSERVER_ADDR=${SUBNET_PREFIX}.5:8000
+    - CHAOS_ADDR=${SUBNET_PREFIX}.10
     ulimits:
       nofile: 131072
     network_mode: host
@@ -81,6 +83,7 @@ services:
       - ${SAFELINE_DIR}/resources/luigi:/app/data
     environment:
       - MGT_IP=${SUBNET_PREFIX}.4
+      - LUIGI_PG=postgres://safeline-ce:${POSTGRES_PASSWORD}@safeline-pg/safeline-ce?sslmode=disable
     logging:
       options:
         max-size: "100m"
@@ -140,6 +143,8 @@ services:
       options:
         max-size: "100m"
         max-file: "5"
+    environment:
+      - DB_ADDR=postgres://safeline-ce:${POSTGRES_PASSWORD}@safeline-pg/safeline-ce?sslmode=disable
     volumes:
       - ${SAFELINE_DIR}/resources/sock:/app/sock
       - ${SAFELINE_DIR}/resources/chaos:/app/chaos


### PR DESCRIPTION
非真人维护说明：此 PR 由自动化维护代理在 okxlin 授权下提交。

## Summary
- 补齐 SafeLine `latest` / `newnet-latest` 与上游 compose 一致的运行环境变量：`TCD_SNSERVER`、`CHAOS_ADDR`、`LUIGI_PG`、`DB_ADDR`。
- 将 `newnet-latest` 默认 `SUBNET_PREFIX` 从 link-local `169.254.0` 调整为 `192.168.255`，避免默认安装撞上云厂商链路本地地址段；字段仍可在安装表单编辑。
- 不做新应用适配，仅修补现有 SafeLine 运行错误。

## Evidence
- Upstream SafeLine compose includes the added variables: `TCD_SNSERVER`, `CHAOS_ADDR`, `LUIGI_PG`, `DB_ADDR`.
- Upstream SafeLine `manage.py` dynamically prefers an unused `192.168.*` subnet before falling back, so the fixed form default now avoids both `169.254.*` and Docker's common `172.*` auto pools.

## Verification
- `git diff --check`
- YAML parse for modified `data.yml` / `docker-compose.yml` files
- `1panel-app-adapter` baseline validation on temporary single-version copies:
  - `latest`: `PASS`, `fail=0 warn=1 info=6`
  - `newnet-latest`: `PASS`, `fail=0 warn=1 info=6`
  - warning is the existing SafeLine environment style detector warning
- `1panel-test-targets` smoke on `moelin/1panel:v2`:
  - `latest`: passed install, running containers, restart, uninstall, cleanup
  - `newnet-latest`: passed install, running containers, restart, uninstall, cleanup
  - local reports: `reports/safeline-latest-smoke-20260626-pass.json`, `reports/safeline-newnet-latest-smoke-20260626-pass.json`

Test harness note: SafeLine is a multi-container app, so the smoke runner was executed from a temporary local copy with only multi-container name querying and post-API-config wait handling adjusted. The app artifacts in this PR were tested unchanged.

Fixes #3299
