### PR TITLE
Add stable compose apps to Renovate whitelist

### DIFF
--- a/.github/renovate-automerge-whitelist.txt
+++ b/.github/renovate-automerge-whitelist.txt
@@ -323,3 +323,16 @@ webgrabplus-linuxserver
 wikijs-linuxserver
 xbackbone-linuxserver
 znc-linuxserver
+# Apps with official GitHub compose/deployment fields unchanged since 2025-06-27 and no high-risk compose flags.
+alist
+aria2-pro
+chatnio
+filecodebox
+gowebdav
+myip
+navidrome
+reubah
+sublink
+twikoo
+vps-stock-monitor
+web-check


### PR DESCRIPTION
## Summary
- add 12 existing apps to the Renovate automerge whitelist
- selected from 124 non-LinuxServer, non-whitelisted GitHub-source apps by checking official repository compose files
- required official compose/deployment fields to be unchanged against the 2025-06-27 baseline and appstore compose to avoid high-risk flags (`privileged`, host network, docker socket, device/cap additions)

## Added apps
- alist
- aria2-pro
- chatnio
- filecodebox
- gowebdav
- myip
- navidrome
- reubah
- sublink
- twikoo
- vps-stock-monitor
- web-check

## Verification
- `git diff --check`
- whitelist validation: no duplicate entries; all new entries have app directories
- evidence validation: all new entries are in the stable compose result set
- high-risk compose scan: no `privileged`, `network_mode`, `/var/run/docker.sock`, `/dev/`, `cap_add`, `pid`, or `ipc` in the selected app compose files

## Notes
- 35 raw stable-compose candidates were found; VPN/virtualization/kernel/network-sensitive, complex migration, testenv compose, or image-source mismatch candidates were left out.
- Existing stale whitelist entries (`pwpush`, `music_tag_web`, `clouddrive2`) pre-date this PR and were not changed.