### PR TITLE
Prune invalid Renovate whitelist entries

### DIFF
--- a/.github/renovate-automerge-whitelist.txt
+++ b/.github/renovate-automerge-whitelist.txt
@@ -1,14 +1,11 @@
 upsnap
-pwpush
 code-server
 zeroclaw
 next-terminal
 dpanel
 wallos
 chatgpt-on-wechat
-music_tag_web
 audiobookshelf
-clouddrive2
 cloudbeaver
 dbgate
 frigate
@@ -256,13 +253,11 @@ changedetection.io-linuxserver
 cops-linuxserver
 davos-linuxserver
 ddclient-linuxserver
-diskover-linuxserver
 dokuwiki-linuxserver
 doplarr-linuxserver
 duckdns-linuxserver
 duplicati-linuxserver
 emby-linuxserver
-fail2ban-linuxserver
 flexget-linuxserver
 foldingathome-linuxserver
 freshrss-linuxserver
@@ -311,7 +306,6 @@ rsnapshot-linuxserver
 sabnzbd-linuxserver
 series-troxide-linuxserver
 sickgear-linuxserver
-socket-proxy-linuxserver
 synclounge-linuxserver
 syslog-ng-linuxserver
 tautulli-linuxserver


### PR DESCRIPTION
## Summary
- remove 3 stale whitelist keys with no matching `apps/<key>` directory: `pwpush`, `music_tag_web`, `clouddrive2`
- remove 3 recently-added LinuxServer keys that have high-risk compose flags and should stay manual: `diskover-linuxserver`, `fail2ban-linuxserver`, `socket-proxy-linuxserver`

## Verification
- `git diff --check`
- whitelist validation: 330 unique entries, no duplicates, no entries missing app directories
- recent stable-compose groups validation: 88 entries, no `privileged`, `network_mode`, Docker socket, `/dev/`, `cap_add`, `pid`, `ipc`, or host-root mount hits

## Follow-up audit notes
48 older whitelisted apps still contain high-risk-ish compose flags such as Docker socket, host network, privileged mode, device mounts, or extra capabilities. Those pre-date this cleanup and should be reviewed as a separate policy decision instead of being removed in bulk here.