### PR TITLE
Restore valid high-risk Renovate whitelist entries

### DIFF
--- a/.github/renovate-automerge-whitelist.txt
+++ b/.github/renovate-automerge-whitelist.txt
@@ -253,11 +253,13 @@ changedetection.io-linuxserver
 cops-linuxserver
 davos-linuxserver
 ddclient-linuxserver
+diskover-linuxserver
 dokuwiki-linuxserver
 doplarr-linuxserver
 duckdns-linuxserver
 duplicati-linuxserver
 emby-linuxserver
+fail2ban-linuxserver
 flexget-linuxserver
 foldingathome-linuxserver
 freshrss-linuxserver
@@ -306,6 +308,7 @@ rsnapshot-linuxserver
 sabnzbd-linuxserver
 series-troxide-linuxserver
 sickgear-linuxserver
+socket-proxy-linuxserver
 synclounge-linuxserver
 syslog-ng-linuxserver
 tautulli-linuxserver


### PR DESCRIPTION
## Summary
- restore `diskover-linuxserver`, `fail2ban-linuxserver`, and `socket-proxy-linuxserver` to the Renovate automerge whitelist
- these app keys are valid and have matching app directories; high-risk compose permissions are allowed to remain in the whitelist by maintainer policy
- keep stale keys without app directories removed: `pwpush`, `music_tag_web`, `clouddrive2`

## Verification
- `git diff --check`
- whitelist validation: 333 unique entries, no duplicates, no entries missing app directories
- confirmed restored entries have matching app directories and stale aliases remain absent