### PR TITLE
Harden Odoo config password rendering

### DIFF
--- a/apps/odoo/latest/docker-compose.yml
+++ b/apps/odoo/latest/docker-compose.yml
@@ -16,12 +16,12 @@ services:
       - -c
     command:
       - |
-        cat > /tmp/odoo.conf <<EOF
-        [options]
-        addons_path = /mnt/extra-addons
-        data_dir = /var/lib/odoo
-        admin_passwd = ${ODOO_MASTER_PASSWORD}
-        EOF
+        {
+          printf '%s\n' '[options]'
+          printf '%s\n' 'addons_path = /mnt/extra-addons'
+          printf '%s\n' 'data_dir = /var/lib/odoo'
+          printf 'admin_passwd = %s\n' "$${ODOO_MASTER_PASSWORD}"
+        } > /tmp/odoo.conf
         exec /entrypoint.sh odoo server -c /tmp/odoo.conf
     environment:
       - TZ=${TZ}
@@ -29,6 +29,7 @@ services:
       - PORT=5432
       - USER=odoo
       - PASSWORD=${POSTGRES_PASSWORD}
+      - ODOO_MASTER_PASSWORD=${ODOO_MASTER_PASSWORD}
     volumes:
       - "${APP_DATA_DIR}/odoo-data:/var/lib/odoo"
       - "${APP_DATA_DIR}/addons:/mnt/extra-addons"


### PR DESCRIPTION
## Summary
- Harden Odoo startup config generation for `ODOO_MASTER_PASSWORD`.
- Keep the generated `/tmp/odoo.conf` approach, but read the master password from the container environment at runtime instead of rendering it directly into the compose command text.

## Risk Review
- No image, port, volume, permission, or service topology changes.
- No old-user migration is required; existing installs keep the same form fields and persisted data paths.
- This only reduces shell/compose expansion risk for generated or user-provided passwords containing characters such as `$`.

## Verification
- `bash /workspace/1panel-app-adapter/repo/scripts/validate-v2.sh --dir apps/odoo --strict-store --source-evidence-mode required`
- `bash /workspace/1panel-app-adapter/repo/scripts/test-env-sample-closure.sh apps/odoo`
- `docker compose --env-file apps/odoo/latest/.env.sample -f apps/odoo/latest/docker-compose.yml config`
- `git diff --check origin/localApps..HEAD`
- 1Panel v2 smoke install with `moelin/1panel:v2` on disposable port `10089`: passed with `ODOO_MASTER_PASSWORD=Odoo$Smoke123!`
- Smoke report: `/tmp/appstore-new-app-smoke-20260627-odoo/odoo-smoke-hardening.json`
- Smoke result: HTTP `/` returned `303 -> /odoo` before and after restart; app was uninstalled and smoke containers were cleaned.
- Minimal Compose escaping check confirmed `$${FOO}` preserves runtime env value `A$B!x` inside the container shell.