### PR TITLE
Fix Odoo startup permissions

### DIFF
--- a/apps/odoo/latest/docker-compose.yml
+++ b/apps/odoo/latest/docker-compose.yml
@@ -2,6 +2,7 @@ services:
   odoo:
     image: "odoo:19.0"
     container_name: ${CONTAINER_NAME}
+    user: root
     restart: always
     depends_on:
       odoo-db:
@@ -16,13 +17,22 @@ services:
       - -c
     command:
       - |
+        set -e
+        install -d -o odoo -g odoo -m 775 /var/lib/odoo /var/lib/odoo/sessions /mnt/extra-addons
+        if [ ! -f /var/lib/odoo/.1panel-permissions-ok ] || [ "$(stat -c '%u:%g' /var/lib/odoo)" != "100:101" ]; then
+          chown -R odoo:odoo /var/lib/odoo /mnt/extra-addons
+          touch /var/lib/odoo/.1panel-permissions-ok
+          chown odoo:odoo /var/lib/odoo/.1panel-permissions-ok
+        fi
         {
           printf '%s\n' '[options]'
           printf '%s\n' 'addons_path = /mnt/extra-addons'
           printf '%s\n' 'data_dir = /var/lib/odoo'
           printf 'admin_passwd = %s\n' "$${ODOO_MASTER_PASSWORD}"
-        } > /tmp/odoo.conf
-        exec /entrypoint.sh odoo server -c /tmp/odoo.conf
+        } > /var/lib/odoo/odoo.conf
+        chown odoo:odoo /var/lib/odoo/odoo.conf
+        chmod 600 /var/lib/odoo/odoo.conf
+        exec setpriv --reuid=odoo --regid=odoo --init-groups /entrypoint.sh odoo server -c /var/lib/odoo/odoo.conf
     environment:
       - TZ=${TZ}
       - HOST=odoo-db


### PR DESCRIPTION
## Summary

- Fix Odoo startup on bind-mounted data directories by repairing Odoo-owned paths inside the container before launch.
- Generate `odoo.conf` under `/var/lib/odoo` instead of `/tmp` so restart does not hit sticky-directory permission protection.
- Drop privileges back to the official `odoo` user before delegating to `/entrypoint.sh`.

## Upgrade / data safety

- No `.env.sample` or install form fields changed.
- No PostgreSQL data path, Odoo filestore path, or addon path changed.
- Existing data is preserved; the wrapper only adjusts ownership for `/var/lib/odoo` and `/mnt/extra-addons` so the official Odoo process can write sessions and config.

Follow-up for #1535 and merged PR #4341.

## Verification

- `bash /workspace/1panel-app-adapter/repo/scripts/validate-v2.sh --dir apps/odoo --version latest --strict-store --source-evidence-mode required --i18n-mode strict --i18n-scope all`
- `git diff --check`
- `python3 /workspace/1panel-test-targets-skill/work/skill-pack/scripts/1panel_app_smoke.py --app-dir /workspace/appstore-renovate-whitelist/apps/odoo --version latest --panel-port 10089 --panel-container 1panel-smoke-10089 --panel-base-dir /tmp/1panel-smoke-10089 --cleanup always --report /tmp/appstore-odoo-smoke-20260628/odoo-smoke-pr.json`
