### PR TITLE
update scripts: erispulse 增强容器脚本兼容性

### DIFF
--- a/apps/erispulse/latest/scripts/init.sh
+++ b/apps/erispulse/latest/scripts/init.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
-set -euo pipefail
-
+if [ -n "${BASH_VERSION:-}" ]; then
+    set -euo pipefail
+else
+    set -eu
+fi
 mkdir -p ./data

--- a/apps/erispulse/latest/scripts/uninstall.sh
+++ b/apps/erispulse/latest/scripts/uninstall.sh
@@ -1,2 +1,7 @@
-#!/bin/bash
-docker-compose down --volumes
+#!/usr/bin/env bash
+if [ -n "${BASH_VERSION:-}" ]; then
+    set -euo pipefail
+else
+    set -eu
+fi
+docker compose down --volumes 2>/dev/null || echo "[ErisPulse] Failed to clean up containers/volumes. Manual check may be required."

--- a/apps/erispulse/latest/scripts/upgrade.sh
+++ b/apps/erispulse/latest/scripts/upgrade.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
-set -euo pipefail
-
+if [ -n "${BASH_VERSION:-}" ]; then
+    set -euo pipefail
+else
+    set -eu
+fi
 exit 0


### PR DESCRIPTION

2026/06/29 16:30:10 安装应用 [erisQvQ] 任务开始 [START]
2026/06/29 16:30:10 开始执行 init 脚本
2026/06/29 16:30:10 执行 init 脚本 失败 : stderr: /opt/1panel/apps/local/erispulse/erisQvQ/scripts/init.sh: line 2: set: pipefail
: invalid option name
, err: exit status 2
2026/06/29 16:30:10 安装应用 [erisQvQ] 失败: stderr: /opt/1panel/apps/local/erispulse/erisQvQ/scripts/init.sh: line 2: set: pipefail
: invalid option name
, err: exit status 2
2026/06/29 16:30:11 [TASK-END]


部分 Shell 环境不支持Bash特性，进行了兼容性修改

修改完后正常：

2026/06/29 16:35:42 安装应用 [erisQvQ] 任务开始 [START]
2026/06/29 16:35:42 开始执行 init 脚本
2026/06/29 16:35:42 执行 init 脚本 成功
2026/06/29 16:35:42 开始拉取镜像 [erispulse/erispulse:latest]



卸载的时候也出现了同样的问题：

2026/06/29 16:37:08 卸载应用 [erispulse] 任务开始 [START]
2026/06/29 16:37:08 停止应用
2026/06/29 16:37:18 停止应用 成功
2026/06/29 16:37:18 开始执行 uninstall 脚本
2026/06/29 16:37:18 执行 uninstall 脚本 失败 : stderr: /opt/1panel/apps/local/erispulse/erispulse/scripts/uninstall.sh: line 2: docker-compose: command not found
, err: exit status 127
2026/06/29 16:37:19 卸载应用 [erispulse] 失败: stderr: /opt/1panel/apps/local/erispulse/erispulse/scripts/uninstall.sh: line 2: docker-compose: command not found
, err: exit status 127
2026/06/29 16:37:20 [TASK-END]

遂也进行了兼容性修改以及兜底：


2026/06/29 16:52:49 卸载应用 [1233] 任务开始 [START]
2026/06/29 16:52:49 停止应用
2026/06/29 16:53:00 停止应用 成功
2026/06/29 16:53:00 开始执行 uninstall 脚本
2026/06/29 16:53:00 执行 uninstall 脚本 成功
2026/06/29 16:53:00 卸载应用 [1233] 成功
2026/06/29 16:53:00 [TASK-END]

其中1233为新装的测试容器名
