### PR TITLE
Fix Renovate app-version workflow false failures

### DIFF
--- a/.github/workflows/renovate-app-version.sh
+++ b/.github/workflows/renovate-app-version.sh
@@ -1,26 +1,50 @@
-#!/bin/bash
-# This script copies the version from docker-compose.yml to config.json.
+#!/usr/bin/env bash
+set -euo pipefail
 
-app_name=$1
-old_version=$2
+# This script renames a version directory to match the image tag from its compose file.
 
-# find all docker-compose files under apps/$app_name (there should be only one)
-docker_compose_files=$(find apps/$app_name/$old_version -name docker-compose.yml)
+app_name=${1:?missing app name}
+old_version=${2:?missing source version}
+source_dir="apps/$app_name/$old_version"
 
-for docker_compose_file in $docker_compose_files
-do
-	# Assuming that the app version will be from the first docker image
-	first_service=$(yq '.services | keys | .[0]' $docker_compose_file)
+case "$old_version" in
+  latest|stable)
+    echo "skip: $source_dir is a rolling alias"
+    exit 0
+    ;;
+esac
 
-	image=$(yq .services.$first_service.image $docker_compose_file)
+if [[ ! -d "$source_dir" ]]; then
+  echo "skip: $source_dir does not exist"
+  exit 0
+fi
 
-	# Only apply changes if the format is <image>:<version>
-	if [[ "$image" == *":"* ]]; then
-	  version=$(cut -d ":" -f2- <<< "$image")
+# Find all docker-compose files under apps/$app_name/$old_version (there should be only one).
+docker_compose_files=$(find "$source_dir" -name docker-compose.yml)
 
-	  # Trim the "v" prefix
-	  trimmed_version=${version/#"v"}
+for docker_compose_file in $docker_compose_files; do
+  # Assume the app version comes from the first service image.
+  first_service=$(yq '.services | keys | .[0]' "$docker_compose_file")
+  image=$(yq ".services.${first_service}.image" "$docker_compose_file")
 
-      mv apps/$app_name/$old_version apps/$app_name/$trimmed_version
-    fi
+  # Only apply changes if the format is <image>:<version>.
+  if [[ "$image" != *":"* ]]; then
+    continue
+  fi
+
+  version=$(cut -d ":" -f2- <<< "$image")
+  trimmed_version=${version/#"v"}
+
+  if [[ -z "$trimmed_version" || "$trimmed_version" == "$old_version" ]]; then
+    echo "skip: $source_dir already matches image tag $version"
+    continue
+  fi
+
+  target_dir="apps/$app_name/$trimmed_version"
+  if [[ -e "$target_dir" ]]; then
+    echo "target already exists: $target_dir" >&2
+    exit 1
+  fi
+
+  mv "$source_dir" "$target_dir"
 done

--- a/.github/workflows/renovate-app-version.yml
+++ b/.github/workflows/renovate-app-version.yml
@@ -10,6 +10,7 @@ on:
         default: ''
 jobs:
   update-app-version:
+    if: github.event_name == 'workflow_dispatch' || github.actor == 'renovate[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -25,7 +26,7 @@ jobs:
       - name: Get list of updated files by the last commit in this branch separated by space
         id: updated-files
         run: |
-          echo "::set-output name=files::$(git diff-tree --no-commit-id --name-only -r ${{ github.sha }} | tr '\n' ' ')"
+          echo "files=$(git diff-tree --no-commit-id --name-only -r ${{ github.sha }} | tr '\n' ' ')" >> "$GITHUB_OUTPUT"
 
       - name: Run renovate-app-version.sh on updated files
         run: |
@@ -33,20 +34,30 @@ jobs:
 
           for file in "${files[@]}"; do
             if [[ $file == *"docker-compose.yml"* ]]; then
-              app_name=$(echo $file | cut -d'/' -f 2)
-              old_version=$(echo $file | cut -d'/' -f 3)
+              app_name=$(echo "$file" | cut -d'/' -f 2)
+              old_version=$(echo "$file" | cut -d'/' -f 3)
               chmod +x .github/workflows/renovate-app-version.sh
-              .github/workflows/renovate-app-version.sh $app_name $old_version
+              .github/workflows/renovate-app-version.sh "$app_name" "$old_version"
             fi
           done
 
       - name: Commit & Push Changes
         run: |
           IFS=' ' read -ra files <<< "${{ steps.updated-files.outputs.files }}"
+          declare -A apps=()
 
           for file in "${files[@]}"; do
             if [[ $file == *"docker-compose.yml"* ]]; then
-              app_name=$(echo $file | cut -d'/' -f 2)
-              git add "apps/$app_name/*" && git commit -m "Update app version [skip ci]" --no-verify && git push || true
+              app_name=$(echo "$file" | cut -d'/' -f 2)
+              apps["$app_name"]=1
             fi
+          done
+
+          for app_name in "${!apps[@]}"; do
+            git add "apps/$app_name"
+            if git diff --cached --quiet; then
+              continue
+            fi
+            git commit -m "Update app version [skip ci]" --no-verify
+            git push
           done


### PR DESCRIPTION
## Summary
- run the update-app-version workflow only for Renovate pushes or manual dispatch
- make the rename helper skip already-renamed version directories and rolling aliases
- keep commit/push handling idempotent for follow-up maintainer patches on Renovate branches

## Why
This fixes the false failure we hit after repairing PR #4511, where a maintainer follow-up push on `renovate/simplexchat-smp-server-7.x` re-ran the version-rename workflow and failed with:

```text
mv: cannot move 'apps/simplex-smp-server/7.0.0' to a subdirectory of itself, 'apps/simplex-smp-server/7.0.0/7.0.0'
```

## Verification
- reproduced the original failure locally with `bash .github/workflows/renovate-app-version.sh simplex-smp-server 7.0.0`
- verified the same command now exits cleanly as a no-op
- verified a temp fixture still renames `apps/demo/1.0.0` to `apps/demo/2.0.0`
- verified a temp fixture skips `latest` without renaming it
- verified an end-to-end temp git repo simulation still creates the follow-up `Update app version [skip ci]` commit and push path
