### PR TITLE
Whitelist azahar-linuxserver for Renovate automerge

### DIFF
--- a/.github/renovate-automerge-whitelist.txt
+++ b/.github/renovate-automerge-whitelist.txt
@@ -87,6 +87,7 @@ atvloadly
 rembg
 cashbook
 autobangumi
+azahar-linuxserver
 pterodactyl-china
 beszel
 beszel-agent


### PR DESCRIPTION
## Summary
- add `azahar-linuxserver` to the Renovate automerge whitelist
- keep the change scoped to whitelist metadata only

## Audit
- scanned recent merged Renovate PRs against the current single-service image-only gate
- `azahar-linuxserver` is a single-service app and its compose has no privileged/host-network/runtime special flags
- recent PR #4519 was an image-only bump under the app path, which matches the current workflow gate shape
- did not whitelist `simplex-smp-server` because it recently needed maintainer packaging/runtime repair
- did not whitelist `rocketchat`, `mastodon-linuxserver`, or `manyfold-linuxserver` because they are multi-service apps and should stay out of the current automerge path

## Verification
- reviewed `.github/workflows/renovate-automerge.yml` and `.github/workflows/renovate-sidecar-guard.yml` against this whitelist addition
- confirmed the diff only adds one app name to `.github/renovate-automerge-whitelist.txt`