### PR TITLE
Soften upgrade-script whitelist heuristic

### DIFF
--- a/.github/renovate-automerge-whitelist-policy.md
+++ b/.github/renovate-automerge-whitelist-policy.md
@@ -19,7 +19,7 @@ Add an app to `.github/renovate-automerge-whitelist.txt` only when all of the fo
 - Single-service apps first.
 - Stable upstream deployment pattern first.
 - No special runtime privileges first.
-- Trivial `upgrade.sh` first.
+- Trivial `upgrade.sh` first, but do not reject a legacy stable app only because `upgrade.sh` is non-empty.
 
 ## Manual caution flags
 
@@ -29,7 +29,7 @@ These do not always block admission, but they should slow us down:
 - `network_mode: host`
 - `runtime: nvidia`
 - `devices`, `cap_add`, `pid: host`, `ipc: host`
-- Non-trivial `scripts/upgrade.sh`
+- Non-trivial `scripts/upgrade.sh` is advisory only; by itself it does not block a stable single-service app
 - Frequent maintainer follow-up commits after Renovate bumps
 
 ## Multi-service apps
@@ -61,3 +61,5 @@ python3 .github/scripts/renovate_whitelist_audit.py \
 ```
 
 The helper is heuristic only. It audits current store packaging, not upstream release intent, so a human still needs to confirm that the upstream compose/deployment pattern is stable enough for automerge.
+
+In particular, the helper reports non-trivial `upgrade.sh` as a caution signal, not a hard failure. For older stable apps, a non-empty upgrade script often reflects migration history rather than ongoing automerge risk.

--- a/.github/scripts/renovate_whitelist_audit.py
+++ b/.github/scripts/renovate_whitelist_audit.py
@@ -116,13 +116,12 @@ def audit_app(repo_root: Path, app: str) -> dict:
     if result["special_flags"]:
         result["notes"].append("special runtime/network privileges present")
     if result["nontrivial_upgrade"]:
-        result["notes"].append("non-trivial upgrade migration present")
+        result["notes"].append("non-trivial upgrade migration present (advisory)")
 
     result["eligible_by_heuristic"] = (
         result["max_services"] == 1
         and result["compose_shape_stable"] is True
         and not result["special_flags"]
-        and not result["nontrivial_upgrade"]
     )
     if result["eligible_by_heuristic"]:
         result["notes"].append("single-service stable candidate")


### PR DESCRIPTION
## Summary
- treat non-empty `upgrade.sh` as a caution signal instead of a hard whitelist rejection
- keep the whitelist policy aligned with stable legacy single-service apps

## Why
- some early apps have non-empty upgrade scripts because they accumulated migration history, not because they are unstable for Renovate image bumps
- single-service plus stable compose should stay the primary gate
- special runtime privileges and multi-service shape still remain the stronger blockers in the helper

## Verification
- `python3 -m py_compile .github/scripts/renovate_whitelist_audit.py`
- `python3 .github/scripts/renovate_whitelist_audit.py --app azahar-linuxserver --app nzbget-linuxserver --app simplex-smp-server --app rocketchat`
- `python3 .github/scripts/renovate_whitelist_audit.py --apps-file .github/renovate-automerge-whitelist.txt --only-problems | sed -n "1,30p"`
- `git diff --check`