### PR TITLE
chore(renovate): whitelist ungoogled-chromium-linuxserver

### DIFF
--- a/.github/renovate-automerge-whitelist.txt
+++ b/.github/renovate-automerge-whitelist.txt
@@ -369,6 +369,7 @@ librewolf-linuxserver
 healthchecks-linuxserver
 flycast-linuxserver
 chrome-linuxserver
+ungoogled-chromium-linuxserver
 signal-linuxserver
 thunderbird-linuxserver
 ting-reader


### PR DESCRIPTION
## Summary
- add `ungoogled-chromium-linuxserver` to the Renovate automerge whitelist

## Why
- single-service app
- current whitelist audit reports stable compose shape and no special runtime flags
- recent Renovate update was effectively image-only
- non-trivial `upgrade.sh` remains advisory only under current policy

## Verification
- `python3 .github/scripts/renovate_whitelist_audit.py --repo-root /workspace/wt-appstore-prs --app ungoogled-chromium-linuxserver --format json`
- `git diff --check`