### PR TITLE
fix: document teldrive runtime linkage limits

### DIFF
--- a/apps/teldrive/README.md
+++ b/apps/teldrive/README.md
@@ -34,7 +34,7 @@ Teldrive is a self-hosted tool for organizing Telegram files through a web inter
 ## 数据持久化
 | 变量 | 说明 | 默认值 | 必填 |
 | --- | --- | --- | --- |
-| APP_DATA_DIR | Teldrive 数据目录，包含 PostgreSQL 数据和本地 storage.db 文件 | ./data | 是 |
+| APP_DATA_DIR | Teldrive 数据目录，包含 PostgreSQL 数据和本地 `storage.db` 文件 | ./data | 是 |
 
 升级或迁移前，请先在 1Panel 中备份上述数据目录。
 
@@ -52,6 +52,8 @@ Teldrive is a self-hosted tool for organizing Telegram files through a web inter
 - 首次访问后需要使用 Telegram 账号登录，并在界面设置中同步频道和默认频道。
 - 如登录停留在登录页，请检查服务器时间同步；也可以在安装参数中启用 `TG_NTP`。
 - `ALLOWED_USERS` 用于限制可登录的 Telegram 用户名，不需要填写 `@`。
+- 已对“复用 1Panel 商店 PostgreSQL runtime”做过真实联动复核，但 Teldrive 当前数据库迁移依赖 `pgroonga` 扩展；标准 `postgresql` 运行时不提供该扩展，启动时会在 `20240711163538_search.sql` 迁移阶段失败。
+- 也额外验证了“补 local app 数据库 runtime 再联动”的路径：一次独立 `localmysql` smoke 中，本地数据库 app 虽然能成功安装并运行，但 `/apps/services/mysql` 返回空，`databases` 资源表也没有生成可复用记录。结合当前 1Panel local app 同步会把数据库 app key 变成 `local...`、而数据库资源登记仍走未加前缀常量的实现路径，这里可以合理推断 local PostgreSQL runtime 目前也不能直接作为 Teldrive 的可选数据库服务。因此当前继续保留上游自带的 `ghcr.io/tgdrive/postgres:17-alpine` 拓扑，而不是切换到商店或 local app PostgreSQL。
 
 ## 参考资料
 - 官网: <https://teldrive-docs.pages.dev/>

--- a/apps/teldrive/latest/scripts/init.sh
+++ b/apps/teldrive/latest/scripts/init.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ENV_FILE="${SCRIPT_DIR}/../.env"
+if [ -f "${ENV_FILE}" ]; then
+  set -a
+  # shellcheck disable=SC1090
+  . "${ENV_FILE}"
+  set +a
+fi
+
 DATA_DIR="${APP_DATA_DIR:-./data}"
 mkdir -p "${DATA_DIR}/postgres"
 touch "${DATA_DIR}/storage.db"

--- a/apps/teldrive/source-evidence.json
+++ b/apps/teldrive/source-evidence.json
@@ -5,6 +5,8 @@
   "notes": [
     "Issue request: https://github.com/okxlin/appstore/issues/2251",
     "Official docs require PostgreSQL and show the ghcr.io/tgdrive/teldrive image.",
-    "The upstream compose directory provides teldrive.yml and postgres.yml examples."
+    "The upstream compose directory provides teldrive.yml and postgres.yml examples.",
+    "A real 1Panel linkage audit against the store PostgreSQL runtime failed because Teldrive's migration 20240711163538_search.sql requires the pgroonga extension, which is not available in the current stock postgresql runtime.",
+    "A separate disposable-panel smoke proved that a local MySQL runtime app can install and run as localmysql, but /apps/services/mysql still returns null and no reusable row is written into the databases table. Based on the shared local-database registration path in current 1Panel source, this is evidence that a local PostgreSQL runtime variant is not yet a safe dependency-binding replacement for Teldrive."
   ]
 }


### PR DESCRIPTION
## Summary
- make `teldrive` install-time init honor panel form values by sourcing the sibling `.env` before using `APP_DATA_DIR`
- document why Teldrive still cannot switch to the stock 1Panel PostgreSQL runtime
- record the follow-up local database runtime experiment outcome in `source-evidence.json`

## Validation
- `bash /workspace/1panel-app-adapter/repo/scripts/validate-v2.sh --dir /workspace/wt-closed-batch-20260706c/apps/teldrive --version latest --strict-store --source-evidence-mode required`
- `bash /workspace/1panel-app-adapter/repo/scripts/test-env-sample-closure.sh /workspace/wt-closed-batch-20260706c/apps/teldrive`
- prior disposable-panel smoke for current `teldrive/latest` stayed passing
- follow-up disposable-panel experiment proved `localmysql` can install but still does not register under `/apps/services/mysql` or the `databases` resource table, so local PostgreSQL runtime reuse remains unsafe for Teldrive today

## Context
Issue: #2251
