### PR TITLE
Fix dootask Redis runtime selector metadata

### DIFF
--- a/apps/dootask/1.8.64/data.yml
+++ b/apps/dootask/1.8.64/data.yml
@@ -160,19 +160,20 @@ additionalProperties:
     - default: ""
       edit: true
       envKey: REDIS_HOST
-      labelEn: Redis Host
-      labelZh: Redis 主机
+      key: redis
+      labelEn: Redis Service
+      labelZh: Redis 服务
       label:
-        en: Redis Host
-        zh: Redis 主机
-        zh-Hant: Redis 主機
-        ja: Redis ホスト
-        ko: Redis 호스트
-        ru: Хост Redis
-        ms: Hos Redis
-        pt-br: Host do Redis
+        en: Redis Service
+        zh: Redis 服务
+        zh-Hant: Redis 服務
+        ja: Redis サービス
+        ko: Redis 서비스
+        ru: Сервис Redis
+        ms: Perkhidmatan Redis
+        pt-br: Serviço Redis
       required: true
-      type: text
+      type: service
     - default: 6379
       edit: true
       envKey: REDIS_PORT

--- a/apps/dootask/README.md
+++ b/apps/dootask/README.md
@@ -8,7 +8,7 @@ DooTask 是一个开源团队协作与任务管理平台，提供项目、任务
 
 - 项目、任务、聊天和文件协作一体化
 - 基于 Laravel Swoole 的实时 Web 与 WebSocket 服务
-- 支持外部 MySQL 与 Redis 依赖
+- 支持通过 1Panel 服务选择器接入外部 MySQL 与 Redis 依赖
 - 首次启动自动拉取固定上游源码与发布版 `vendor` 依赖
 
 ## 访问说明
@@ -25,7 +25,7 @@ DooTask is an open source team collaboration and task management platform with p
 
 - Unified projects, tasks, chat, and file collaboration
 - Laravel plus Swoole realtime web and WebSocket stack
-- External MySQL and Redis dependency support
+- External MySQL and Redis dependency support through 1Panel service selectors
 - First startup bootstraps the fixed upstream source tarball and released vendor bundle
 
 ## 部署说明
@@ -34,7 +34,7 @@ DooTask is an open source team collaboration and task management platform with p
 - PHP 运行镜像使用维护者发布的 `kuaifan/php:swoole-8.4@sha256:4f69395d5b8a72256338aa6042a6caaaf598bb5cc0b4ab30a84ef9cc4c5e61e2`。
 - Nginx 使用官方镜像 `nginx:1.27-alpine@sha256:65645c7bb6a0661892a8b03b89d0743208a18dd2f3f17a54ef4b76fb8e2f2a10`。
 - 上游官方 compose 还包含 `mariadb`、`redis` 和 `appstore` sidecar；其中 `appstore` sidecar 依赖 `privileged` 与 Docker Socket，但它不是主站启动必需组件，因此本适配明确移除。
-- 数据库表单按 MySQL 服务实例/服务名接入设计，可对接可达的 MySQL 服务；当前这棵分支没有可复用的 Redis runtime 包，所以 Redis 先使用手动主机/端口/密码配置，并在此明确标注。
+- 数据库与 Redis 表单都按 1Panel 服务实例/服务名接入设计：MySQL 使用数据库服务选择器，Redis 使用 `key: redis` 的服务选择器；运行时仍保持 `PANEL_DB_HOST` / `REDIS_HOST` 等既有环境变量，避免升级时破坏老用户现有 `.env`。
 - 上游 `v1.8.64` 有少量历史 migration 与现代 MySQL 8 严格模式不兼容，包括 `TEXT default ''` 和一条 `distinct + chunk` 查询排序问题；本适配会在首次解包源码后仅对这些已确认 migration 做幂等兼容修补，再继续官方迁移流程。
 
 ## 端口
@@ -63,7 +63,7 @@ DooTask is an open source team collaboration and task management platform with p
 | `PANEL_DB_USER` | DooTask 数据库用户 | `dootask` | 是 |
 | `PANEL_DB_USER_PASSWORD` | DooTask 数据库密码 | 随机生成 | 是 |
 | `DB_PREFIX` | 数据表前缀 | `pre_` | 是 |
-| `REDIS_HOST` | Redis 主机名或服务名 | 空 | 是 |
+| `REDIS_HOST` | 1Panel Redis 服务实例 | 空 | 是 |
 | `REDIS_PORT` | Redis 端口 | `6379` | 是 |
 | `PANEL_REDIS_ROOT_PASSWORD` | Redis 密码；无密码时填字面量 `null` | `null` | 是 |
 | `REDIS_DB` | Redis 逻辑库编号 | `0` | 是 |
@@ -76,18 +76,20 @@ DooTask is an open source team collaboration and task management platform with p
 
 - 数据库为空时，安装脚本会自动创建首个管理员；如果数据库里已经有用户，则不会覆盖已有账号。
 - `PANEL_REDIS_ROOT_PASSWORD` 需要与目标 Redis 实例实际配置一致；如果 Redis 没启用密码认证，请填写字面量 `null`。
+- 若安装界面暂时没有可选 Redis 服务，请先在当前 1Panel 中安装并确认可复用的 Redis 应用实例。
 - 如需公网访问，请在首次启动后按实际域名或反向代理情况检查 `APP_DATA_DIR/app/.env` 中的 `APP_URL`，必要时手动改为真实外部 URL。
 - `/health` 可用于基础存活检查；计划任务由容器内 cron 继续调用上游 `/crontab` 路由。
-- 如果目标是 local app 数据库，请先确认该服务实例在当前面板中能被其他应用实际访问；本包当前实测通过的是“可达 MySQL/Redis 服务”安装路径。
+- 如果目标是 local app 数据库或 Redis，请先确认该服务实例在当前面板中能被其他应用实际访问；本包当前审计重点验证的是 1Panel 依赖服务选择链路，而不是手工填写主机名的旁路安装。
 
 ## 风险与升级说明
 
 - 这是一个上游源码首启下载型包，而不是纯镜像即开即用包；首次安装耗时明显高于普通应用。
 - 当前包固定到 `v1.8.64` 发布线，`latest` 目录也同样固定到这一版本。
 - 为兼容现代 MySQL 8 安装，入口脚本会对上游少量已确认的历史 migration 做一次性本地修补；这不会自动升级到其他上游版本。
+- Redis 服务选择器这次只修正了安装表单元数据，未改动实际运行时 envKey，因此老用户已有 `REDIS_HOST` / `REDIS_PORT` / `PANEL_REDIS_ROOT_PASSWORD` 配置仍可直接沿用。
 - 自动 in-place 源码升级暂未放开；`upgrade.sh` 只输出明确提醒，不会做破坏性迁移。
 - 直接更换到未来版本前，请先完整备份 `APP_DATA_DIR/app`、外部 MySQL 数据库和 Redis 数据，并先做专项升级 smoke。
-- 由于 Redis 当前不是商店内可复用 runtime，这个包暂不加入 Renovate 自动合并白名单。
+- 当前包仍不加入 Renovate 自动合并白名单。
 
 ## 参考资料
 

--- a/apps/dootask/latest/data.yml
+++ b/apps/dootask/latest/data.yml
@@ -160,19 +160,20 @@ additionalProperties:
     - default: ""
       edit: true
       envKey: REDIS_HOST
-      labelEn: Redis Host
-      labelZh: Redis 主机
+      key: redis
+      labelEn: Redis Service
+      labelZh: Redis 服务
       label:
-        en: Redis Host
-        zh: Redis 主机
-        zh-Hant: Redis 主機
-        ja: Redis ホスト
-        ko: Redis 호스트
-        ru: Хост Redis
-        ms: Hos Redis
-        pt-br: Host do Redis
+        en: Redis Service
+        zh: Redis 服务
+        zh-Hant: Redis 服務
+        ja: Redis サービス
+        ko: Redis 서비스
+        ru: Сервис Redis
+        ms: Perkhidmatan Redis
+        pt-br: Serviço Redis
       required: true
-      type: text
+      type: service
     - default: 6379
       edit: true
       envKey: REDIS_PORT

--- a/apps/dootask/source-evidence.json
+++ b/apps/dootask/source-evidence.json
@@ -10,7 +10,7 @@
     "Issue request: https://github.com/okxlin/appstore/issues/2744",
     "Verified on 2026-07-06 that the latest upstream release is v1.8.64, published on 2026-07-02.",
     "The official upstream compose bundles php, nginx, redis, mariadb, and an optional appstore sidecar.",
-    "This adaptation keeps the official php plus nginx topology, targets an externally reachable MySQL service through 1Panel-style service linkage, and removes the non-essential privileged appstore sidecar plus Docker socket mount.",
+    "This adaptation keeps the official php plus nginx topology, targets externally reachable MySQL and Redis services through 1Panel-style service linkage, and removes the non-essential privileged appstore sidecar plus Docker socket mount.",
     "The package bootstraps a fixed upstream source tarball and the release vendor.tar.gz asset into APP_DATA_DIR on first start so container recreation does not silently upgrade users.",
     "Because upstream v1.8.64 ships a few historical migrations that are incompatible with modern MySQL 8 strict mode, the entrypoint applies an idempotent local compatibility patch before running the official migration flow."
   ]


### PR DESCRIPTION
## Summary
- switch `dootask` `REDIS_HOST` in both `1.8.64` and `latest` from manual text input to a real 1Panel Redis service selector
- keep the effective runtime env key unchanged for upgrade safety, so existing `.env` values still map to `REDIS_HOST`
- update `README.md` and `source-evidence.json` to document selector-backed Redis reuse and the upgrade-safety rationale

## Validation
- `bash /workspace/1panel-app-adapter/repo/scripts/validate-v2.sh --dir /workspace/wt-runtime-audit-localapps/apps/dootask --version 1.8.64 --strict-store`
- `bash /workspace/1panel-app-adapter/repo/scripts/validate-v2.sh --dir /workspace/wt-runtime-audit-localapps/apps/dootask --version latest --strict-store`
- real smoke report already captured locally for selector-backed install, `/health`, restart, uninstall, and cleanup

## Notes
- this follows up the same runtime-selector class of issue already fixed for `jianmu`
- no test reports are committed into the appstore tree
