### PR TITLE
fix: refresh dootask nginx and jianmu worker images

### DIFF
--- a/apps/dootask/1.8.64/docker-compose.yml
+++ b/apps/dootask/1.8.64/docker-compose.yml
@@ -44,7 +44,7 @@ services:
       createdBy: "Apps"
 
   nginx:
-    image: "nginx:1.27-alpine@sha256:65645c7bb6a0661892a8b03b89d0743208a18dd2f3f17a54ef4b76fb8e2f2a10"
+    image: "nginx:1.31-alpine@sha256:54f2a904c251d5a34adf545a72d32515a15e08418dae0266e23be2e18c66fefa"
     container_name: ${CONTAINER_NAME}-nginx
     restart: always
     depends_on:

--- a/apps/dootask/latest/docker-compose.yml
+++ b/apps/dootask/latest/docker-compose.yml
@@ -44,7 +44,7 @@ services:
       createdBy: "Apps"
 
   nginx:
-    image: "nginx:1.27-alpine@sha256:65645c7bb6a0661892a8b03b89d0743208a18dd2f3f17a54ef4b76fb8e2f2a10"
+    image: "nginx:1.31-alpine@sha256:54f2a904c251d5a34adf545a72d32515a15e08418dae0266e23be2e18c66fefa"
     container_name: ${CONTAINER_NAME}-nginx
     restart: always
     depends_on:

--- a/apps/jianmu/2.8.2/docker-compose.yml
+++ b/apps/jianmu/2.8.2/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       createdBy: "Apps"
 
   jianmu-worker:
-    image: "docker.jianmuhub.com/jianmu/jianmu-worker-docker:v1.0.13@sha256:44e57f3263569ae1ab177a7c1053d04e518482b2ba658c6001db9ee96e523529"
+    image: "docker.jianmuhub.com/jianmu/jianmu-worker-docker:v1.0.14@sha256:bcb45def4af7133b0c5b7a49fa36158c6d8a71e8fbcb1806b179e7b954f7b5af"
     container_name: ${CONTAINER_NAME}-worker
     restart: always
     depends_on:

--- a/apps/jianmu/latest/docker-compose.yml
+++ b/apps/jianmu/latest/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       createdBy: "Apps"
 
   jianmu-worker:
-    image: "docker.jianmuhub.com/jianmu/jianmu-worker-docker:v1.0.13@sha256:44e57f3263569ae1ab177a7c1053d04e518482b2ba658c6001db9ee96e523529"
+    image: "docker.jianmuhub.com/jianmu/jianmu-worker-docker:v1.0.14@sha256:bcb45def4af7133b0c5b7a49fa36158c6d8a71e8fbcb1806b179e7b954f7b5af"
     container_name: ${CONTAINER_NAME}-worker
     restart: always
     depends_on:


### PR DESCRIPTION
## Summary
- refresh `dootask` nginx sidecar image in `latest` and `1.8.64`
- refresh `jianmu` worker image in `latest` and `2.8.2`
- keep stable version directory names unchanged, replacing the closed unsafe Renovate attempts from PR #4563 and PR #4565

## Validation
- `bash /workspace/1panel-app-adapter/repo/scripts/validate-v2.sh --dir /workspace/wt-runtime-audit-localapps/apps/dootask --version latest --strict-store`
- `bash /workspace/1panel-app-adapter/repo/scripts/validate-v2.sh --dir /workspace/wt-runtime-audit-localapps/apps/dootask --version 1.8.64 --strict-store`
- `bash /workspace/1panel-app-adapter/repo/scripts/validate-v2.sh --dir /workspace/wt-runtime-audit-localapps/apps/jianmu --version latest --strict-store`
- `bash /workspace/1panel-app-adapter/repo/scripts/validate-v2.sh --dir /workspace/wt-runtime-audit-localapps/apps/jianmu --version 2.8.2 --strict-store`
- real 1Panel smoke install / restart / uninstall cleanup passed for:
  - `dootask latest`
  - `dootask 1.8.64`
  - `jianmu latest`
  - `jianmu 2.8.2`

## Notes
- smoke evidence confirmed `dootask` runs `nginx:1.31-alpine@sha256:54f2a904c251d5a34adf545a72d32515a15e08418dae0266e23be2e18c66fefa`
- smoke evidence confirmed `jianmu` runs `docker.jianmuhub.com/jianmu/jianmu-worker-docker:v1.0.14@sha256:bcb45def4af7133b0c5b7a49fa36158c6d8a71e8fbcb1806b179e7b954f7b5af`
