### PR TITLE
chore(renovate): whitelist darktable-linuxserver

### DIFF
--- a/.github/renovate-automerge-whitelist.txt
+++ b/.github/renovate-automerge-whitelist.txt
@@ -369,6 +369,7 @@ librewolf-linuxserver
 healthchecks-linuxserver
 flycast-linuxserver
 chrome-linuxserver
+darktable-linuxserver
 ungoogled-chromium-linuxserver
 signal-linuxserver
 thunderbird-linuxserver


### PR DESCRIPTION
## Summary
- add `darktable-linuxserver` to the Renovate automerge whitelist

## Why
- single-service app
- current whitelist audit reports stable compose shape and no special runtime flags
- recent Renovate update was effectively image-only
- non-trivial `upgrade.sh` remains advisory only under current policy

## Verification
- `python3 .github/scripts/renovate_whitelist_audit.py --repo-root /workspace/wt-appstore-prs --app darktable-linuxserver --format json`
- `git diff --check`