### PR TITLE
chore(renovate): whitelist roundcube and rustdesk-linuxserver

### DIFF
--- a/.github/renovate-automerge-whitelist.txt
+++ b/.github/renovate-automerge-whitelist.txt
@@ -212,6 +212,7 @@ qbittorrent-vnc
 qiandao
 rathole
 resilio-sync
+roundcube
 rss-reader
 rss-to-telegram-bot
 samba
@@ -314,6 +315,7 @@ pyload-ng-linuxserver
 qbittorrent-linuxserver
 raneto-linuxserver
 rsnapshot-linuxserver
+rustdesk-linuxserver
 sabnzbd-linuxserver
 series-troxide-linuxserver
 sickgear-linuxserver


### PR DESCRIPTION
## Summary\n- add `roundcube` to the Renovate automerge whitelist\n- add `rustdesk-linuxserver` to the Renovate automerge whitelist\n\n## Why\nBoth apps just passed maintainer review as low-risk single-service image updates with stable compose shape, so future Renovate bumps can follow the whitelist path automatically.