### PR TITLE
feat(immich): add v3.0.2 upgrade path

### DIFF
--- a/apps/immich/3.0.2/.env.sample
+++ b/apps/immich/3.0.2/.env.sample
@@ -1,0 +1,10 @@
+
+CONTAINER_NAME="immich"
+PANEL_APP_PORT_HTTP="40194"
+PANEL_DB_NAME="immich"
+PANEL_DB_USER="postgres"
+PANEL_DB_USER_PASSWORD="immich_BfcHCZ"
+UPLOAD_LOCATION="./data/upload"
+CACHE_PATH="./data/cache"
+DB_PATH="./data/data"
+DB_STORAGE_TYPE="SSD"

--- a/apps/immich/3.0.2/data.yml
+++ b/apps/immich/3.0.2/data.yml
@@ -1,0 +1,140 @@
+additionalProperties:
+  formFields:
+    - default: 40194
+      edit: true
+      envKey: PANEL_APP_PORT_HTTP
+      labelEn: Port
+      labelZh: 端口
+      label:
+        en: 'Port'
+        zh: '端口'
+        zh-Hant: '埠'
+        ja: 'ポート'
+        ko: '포트'
+        ru: 'Порт'
+        ms: 'Port'
+        pt-br: 'Porta'
+      required: true
+      rule: paramPort
+      type: number
+    - default: ./data/upload
+      edit: true
+      envKey: UPLOAD_LOCATION
+      labelEn: Path to folder for uploading
+      labelZh: 上传用文件夹路径
+      label:
+        en: 'Path to folder for uploading'
+        zh: '上传用文件夹路径'
+        zh-Hant: '上傳用資料夾路徑'
+        ja: 'アップロード用フォルダーパス'
+        ko: '업로드 폴더 경로'
+        ru: 'Путь к папке для загрузки'
+        ms: 'Laluan folder untuk muat naik'
+        pt-br: 'Caminho da pasta para upload'
+      required: true
+      type: text
+    - default: ./data/cache
+      edit: true
+      envKey: CACHE_PATH
+      labelEn: Cache folder path
+      labelZh: 缓存文件夹路径
+      label:
+        en: 'Cache folder path'
+        zh: '缓存文件夹路径'
+        zh-Hant: '快取資料夾路徑'
+        ja: 'キャッシュフォルダーパス'
+        ko: '캐시 폴더 경로'
+        ru: 'Путь к папке кэша'
+        ms: 'Laluan folder cache'
+        pt-br: 'Caminho da pasta de cache'
+      required: true
+      type: text
+    - default: ./data/data
+      edit: true
+      envKey: DB_PATH
+      labelEn: Database folder path
+      labelZh: 数据库文件夹路径
+      label:
+        en: 'Database folder path'
+        zh: '数据库文件夹路径'
+        zh-Hant: '資料庫資料夾路徑'
+        ja: 'データベースフォルダーパス'
+        ko: '데이터베이스 폴더 경로'
+        ru: 'Путь к папке базы данных'
+        ms: 'Laluan folder pangkalan data'
+        pt-br: 'Caminho da pasta do banco de dados'
+      required: true
+      type: text
+    - default: SSD
+      edit: true
+      envKey: DB_STORAGE_TYPE
+      labelEn: Database storage type
+      labelZh: 数据库存储类型
+      label:
+        en: Database storage type
+        zh: 数据库存储类型
+        zh-Hant: 資料庫儲存類型
+        ja: データベースストレージ種別
+        ko: 데이터베이스 저장소 유형
+        ru: Тип хранилища базы данных
+        ms: Jenis storan pangkalan data
+        pt-br: Tipo de armazenamento do banco
+      required: true
+      type: select
+      values:
+        - label: SSD
+          value: SSD
+        - label: HDD
+          value: HDD
+    - default: immich
+      edit: true
+      envKey: PANEL_DB_NAME
+      labelEn: Database
+      labelZh: 数据库名
+      label:
+        en: 'Database'
+        zh: '数据库名'
+        zh-Hant: '數據庫名'
+        ja: 'データベース'
+        ko: '데이터베이스'
+        ru: 'База данных'
+        ms: 'Pangkalan Data'
+        pt-br: 'Banco de Dados'
+      required: true
+      rule: paramCommon
+      type: text
+    - default: postgres
+      edit: true
+      envKey: PANEL_DB_USER
+      labelEn: Postgres User
+      labelZh: Postgres 数据库用户
+      label:
+        en: 'Postgres User'
+        zh: 'Postgres 数据库用户'
+        zh-Hant: 'Postgres 資料庫使用者'
+        ja: 'Postgres ユーザー'
+        ko: 'Postgres 사용자'
+        ru: 'Пользователь Postgres'
+        ms: 'Pengguna Postgres'
+        pt-br: 'Usuário do Postgres'
+      required: true
+      rule: paramCommon
+      type: text
+    - default: immich
+      edit: true
+      envKey: PANEL_DB_USER_PASSWORD
+      labelEn: Postgres Password
+      labelZh: Postgres 数据库用户密码
+      label:
+        en: 'Postgres Password'
+        zh: 'Postgres 数据库用户密码'
+        zh-Hant: 'Postgres 資料庫使用者密碼'
+        ja: 'Postgres パスワード'
+        ko: 'Postgres 비밀번호'
+        ru: 'Пароль Postgres'
+        ms: 'Kata laluan Postgres'
+        pt-br: 'Senha do Postgres'
+      random: true
+      required: true
+      rule: paramComplexity
+      type: password

--- a/apps/immich/3.0.2/docker-compose.yml
+++ b/apps/immich/3.0.2/docker-compose.yml
@@ -1,0 +1,79 @@
+services:
+  immich-server:
+    container_name: ${CONTAINER_NAME}-server
+    restart: always
+    networks:
+      - 1panel-network
+    image: ghcr.io/immich-app/immich-server:v3.0.2
+    volumes:
+      - ${UPLOAD_LOCATION}:/data
+      - /etc/localtime:/etc/localtime:ro
+    environment:
+      - DB_PASSWORD=${PANEL_DB_USER_PASSWORD}
+      - DB_HOSTNAME=${CONTAINER_NAME}-postgres
+      - DB_USERNAME=${PANEL_DB_USER}
+      - DB_DATABASE_NAME=${PANEL_DB_NAME}
+      - REDIS_HOSTNAME=${CONTAINER_NAME}-redis
+    ports:
+      - ${PANEL_APP_PORT_HTTP}:2283
+    depends_on:
+      - immich-redis
+      - immich-database
+    healthcheck:
+      disable: false
+    labels:
+      createdBy: "Apps"
+
+  immich-machine-learning:
+    container_name: ${CONTAINER_NAME}-machine_learning
+    restart: always
+    networks:
+      - 1panel-network
+    image: ghcr.io/immich-app/immich-machine-learning:v3.0.2
+    volumes:
+      - ${CACHE_PATH}:/cache
+    environment:
+      - DB_PASSWORD=${PANEL_DB_USER_PASSWORD}
+      - DB_HOSTNAME=${CONTAINER_NAME}-postgres
+      - DB_USERNAME=${PANEL_DB_USER}
+      - DB_DATABASE_NAME=${PANEL_DB_NAME}
+      - REDIS_HOSTNAME=${CONTAINER_NAME}-redis
+    healthcheck:
+      disable: false
+    labels:
+      createdBy: "Apps"
+
+  immich-redis:
+    container_name: ${CONTAINER_NAME}-redis
+    restart: always
+    networks:
+      - 1panel-network
+    image: "docker.io/valkey/valkey:9@sha256:4963247afc4cd33c7d3b2d2816b9f7f8eeebab148d29056c2ca4d7cbc966f2d9"
+    healthcheck:
+      test: redis-cli ping || exit 1
+    labels:
+      createdBy: "Apps"
+
+  immich-database:
+    container_name: ${CONTAINER_NAME}-postgres
+    restart: always
+    networks:
+      - 1panel-network
+    image: "ghcr.io/immich-app/postgres:14-vectorchord0.4.3-pgvectors0.2.0@sha256:bcf63357191b76a916ae5eb93464d65c07511da41e3bf7a8416db519b40b1c23"
+    environment:
+      - POSTGRES_PASSWORD=${PANEL_DB_USER_PASSWORD}
+      - POSTGRES_USER=${PANEL_DB_USER}
+      - POSTGRES_DB=${PANEL_DB_NAME}
+      - POSTGRES_INITDB_ARGS=--data-checksums
+      - DB_STORAGE_TYPE=${DB_STORAGE_TYPE:-SSD}
+    volumes:
+      - ${DB_PATH}:/var/lib/postgresql/data
+    shm_size: 128mb
+    healthcheck:
+      disable: false
+    labels:
+      createdBy: "Apps"
+
+networks:
+  1panel-network:
+    external: true

--- a/apps/immich/3.0.2/scripts/init.sh
+++ b/apps/immich/3.0.2/scripts/init.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mkdir -p \
+  "${UPLOAD_LOCATION:-./data/upload}" \
+  "${CACHE_PATH:-./data/cache}" \
+  "${DB_PATH:-./data/data}"

--- a/apps/immich/3.0.2/scripts/uninstall.sh
+++ b/apps/immich/3.0.2/scripts/uninstall.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+docker compose down --volumes --remove-orphans

--- a/apps/immich/3.0.2/scripts/upgrade.sh
+++ b/apps/immich/3.0.2/scripts/upgrade.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ENV_FILE="${ENV_FILE:-./.env}"
+
+if [[ ! -f "$ENV_FILE" ]]; then
+  echo "$ENV_FILE not found; skipped Immich environment migration"
+  exit 0
+fi
+
+if grep -qE '^DB_STORAGE_TYPE=' "$ENV_FILE"; then
+  echo "DB_STORAGE_TYPE already exists"
+else
+  printf '%s\n' 'DB_STORAGE_TYPE=SSD' >> "$ENV_FILE"
+  echo "Added DB_STORAGE_TYPE"
+fi

--- a/apps/immich/README.md
+++ b/apps/immich/README.md
@@ -1,15 +1,32 @@
 # Immich
 
-## 应用简介
-高性能的自托管照片和视频备份方案。
+## 产品介绍
+Immich 是一个高性能的开源照片和视频管理平台，可将移动设备媒体备份到自托管服务器，并提供时间线、相册、搜索、人脸识别和机器学习功能。
 
-英文说明：High performance self-hosted photo and video backup solution.
+## 主要功能
+- 自动备份和管理照片、视频
+- 支持时间线、相册、分享和地图
+- 提供人脸识别、智能搜索和机器学习服务
+- 使用 PostgreSQL、VectorChord 和 Valkey 保存索引与任务状态
+
+## 访问说明
+- Web 入口：安装后通过 `http://<服务器 IP>:<HTTP 端口>` 访问。
+- 实际端口以安装时填写的 `PANEL_APP_PORT_HTTP` 为准。
+
+## Introduction
+Immich is a high-performance open source photo and video management platform for backing up mobile media to a self-hosted server. It includes timelines, albums, search, facial recognition and machine-learning features.
+
+## Features
+- Automatically backs up and manages photos and videos
+- Supports timelines, albums, sharing and maps
+- Provides facial recognition, smart search and machine learning
+- Uses PostgreSQL, VectorChord and Valkey for indexes and job state
 
 ## 部署说明
 - 本应用使用 Docker Compose 在 1Panel 中部署。
 - 应用分类：媒体。
 - 支持架构：amd64。
-- 可选版本：`release`、`1.122.3`、`1.132.3`。
+- 可选版本以应用商店页面为准。
 - 安装后按应用表单中的端口访问 Web UI、SSH 或对应服务。
 
 ## 端口
@@ -26,11 +43,13 @@
 
 升级或迁移前，请在 1Panel 中备份上述数据目录。
 
-升级到 `1.132.3` 前请特别注意：
+从 `1.132.3` 升级到 `3.0.2` 前请特别注意：
 
-- `1.132.3` 保持 `UPLOAD_LOCATION`、`CACHE_PATH`、`DB_PATH` 持久化路径不变，但服务镜像切换为官方 `ghcr.io/immich-app/*`，缓存服务由 Redis 6.2 切换为 Valkey 8。
-- Immich 官方建议升级前阅读对应版本 release notes，确认 breaking changes；请同时备份上传目录并通过数据库导出方式备份 Postgres，直接热拷贝 `DB_PATH` 不能作为可靠数据库备份。
-- 如使用 Authelia OAuth，`v1.132.3` release notes 要求 Authelia 配置包含 `token_endpoint_auth_method: "client_secret_post"`。
+- 必须先备份 `UPLOAD_LOCATION`，并通过 PostgreSQL 导出方式备份数据库；运行中的 `DB_PATH` 热拷贝不能作为可靠数据库备份。
+- 数据库镜像会从已弃用的 `pgvecto-rs` 切换到官方 VectorChord 兼容镜像。首次启动会执行扩展迁移和索引重建，大型图库可能需要较长时间。
+- 完成 VectorChord 迁移后不可降级到低于 `1.133.0` 的 Immich 版本。
+- v3 包含 API 等破坏性变更，依赖 Immich API 的第三方工具需要按官方 v3 migration guide 检查兼容性。
+- 移动客户端应在服务器升级前更新到与服务器主版本兼容的版本。
 
 ## 配置项
 | 变量 | 说明 | 默认值 | 必填 |
@@ -38,13 +57,17 @@
 | PANEL_DB_NAME | 数据库名 | immich | 是 |
 | PANEL_DB_USER | Postgres 数据库用户 | postgres | 是 |
 | PANEL_DB_USER_PASSWORD | Postgres 数据库用户密码 | immich | 是 |
+| DB_STORAGE_TYPE | 数据库存储介质类型 | SSD | 是 |
 
 ## 使用说明
 - 安装完成后，在 1Panel 应用页面查看运行状态、端口和日志。
+- 数据库位于机械硬盘时将 `DB_STORAGE_TYPE` 设为 `HDD`，SSD 或 NVMe 保持 `SSD`。
 - 首次启用前，请按安装表单填写域名、账号、密码、Token、数据目录等参数。
 - 如需对外开放访问，请同步检查防火墙、安全组和反向代理配置。
 
 ## 参考资料
 - 官网: <https://immich.app>
-- 文档: <https://immich.app/docs>
+- 文档: <https://docs.immich.app>
+- v3 迁移指南: <https://immich.app/blog/v3-migration>
+- VectorChord 升级说明: <https://docs.immich.app/install/upgrading/#migrating-to-vectorchord>
 - 源码: <https://github.com/immich-app/immich>

--- a/apps/immich/data.yml
+++ b/apps/immich/data.yml
@@ -25,7 +25,6 @@ additionalProperties:
   recommend: 0
   website: https://immich.app
   github: https://github.com/immich-app/immich
-  document: https://immich.app/docs
+  document: https://docs.immich.app
   architectures:
     - amd64
-

--- a/renovate.json
+++ b/renovate.json
@@ -466,6 +466,35 @@
       "enabled": false
     },
     {
+      "description": "Keep Immich 1.132.3 as the pgvecto.rs to VectorChord migration bridge",
+      "matchFileNames": [
+        "apps/immich/1.132.3/docker-compose.yml"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "Group Immich server and machine-learning images",
+      "matchFileNames": [
+        "apps/immich/3.*/docker-compose.yml"
+      ],
+      "matchPackageNames": [
+        "ghcr.io/immich-app/immich-server",
+        "ghcr.io/immich-app/immich-machine-learning"
+      ],
+      "groupName": "Immich application images"
+    },
+    {
+      "description": "Disable sidecar-only Renovate updates for Immich multi-service tracks",
+      "matchFileNames": [
+        "apps/immich/3.*/docker-compose.yml"
+      ],
+      "matchPackageNames": [
+        "docker.io/valkey/valkey",
+        "ghcr.io/immich-app/postgres"
+      ],
+      "enabled": false
+    },
+    {
       "description": "Require dashboard approval for major updates of stateful Docker sidecars",
       "matchDatasources": [
         "docker"


### PR DESCRIPTION
## 变更说明

- 新增 Immich 3.0.2 数字版本，保留 1.132.3 作为 pgvecto.rs 到 VectorChord 的迁移桥梁
- 同步官方 v3 compose：`/data` 媒体挂载、Valkey 9、VectorChord 兼容 PostgreSQL 镜像及 `shm_size`
- 增加 SSD/HDD 数据库存储类型表单和老用户 `.env` 升级迁移
- 更新 README 的 v3 备份、不可降级和客户端兼容警告
- 调整 Renovate：冻结 1.132.3，成组更新 server/ML，禁止辅助数据库和 Valkey 单独推送

## 验证

- adapter strict-store + strict i18n：通过
- 镜像 manifest/digest：通过
- 实测 1.132.3 -> 3.0.2：4 个服务 healthy，HTTP 200
- PostgreSQL：38 张表迁移为 66 张，`vchord 0.4.3` 与 `vector 0.8.1` 生效
- 迁移后完整停启：通过，`immich-admin schema-check` 无 schema drift
- 日志密钥与致命错误扫描：通过