### PR TITLE
chore(librechat): refresh tested image digest

### DIFF
--- a/apps/librechat/latest/docker-compose.yml
+++ b/apps/librechat/latest/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   librechat-api:
-    image: "registry.librechat.ai/danny-avila/librechat-dev:latest@sha256:643075c6ea40b4f1a6600950fd1bd46c1f1dd399b38559594a44999f15ee22f3"
+    image: "registry.librechat.ai/danny-avila/librechat-dev:latest@sha256:7f95c733d6c9b29de9feb7dd14efa8b29cb0d369bf49710daf7e9b302a8bbe41"
     container_name: ${CONTAINER_NAME}
     user: root
     restart: always


### PR DESCRIPTION
## 变更
- 更新 LibreChat 主服务 `latest@sha256` 到已测试摘要 `7f95c73...`。
- 其余五个服务镜像和部署参数保持不变。

## 验证
- 镜像构建窗口对应上游 6 个应用代码提交，官方 `docker-compose.yml` 无变化。
- 真实 1Panel v2 六服务升级测试通过：API、Admin、MongoDB、Meilisearch、pgvector 和 RAG API 全部 healthy。
- 主界面 HTTP 200，整栈重启后仍可访问。
- MongoDB 持久化标记在重启后保留。
- 全容器日志扫描未发现测试密钥或 `KEY=value` 形式的敏感信息泄露。
- Adapter 严格校验通过。
- Trivy：`Critical=0`、`High=3`。

来源：Renovate Dependency Dashboard #13。