### PR TITLE
Use 1Panel database services for RomM

### DIFF
--- a/apps/romm/4.9.2/.env.sample
+++ b/apps/romm/4.9.2/.env.sample
@@ -1,9 +1,11 @@
 PANEL_APP_PORT_HTTP=8080
 APP_DATA_DIR=./data
-DB_NAME=romm
-DB_USER=romm-user
-DB_PASSWORD=replace-with-a-strong-password
-DB_ROOT_PASSWORD=replace-with-a-different-strong-password
+PANEL_DB_TYPE=mariadb
+PANEL_DB_HOST=mariadb
+PANEL_DB_PORT=3306
+PANEL_DB_NAME=romm
+PANEL_DB_USER=romm-user
+PANEL_DB_USER_PASSWORD=replace-with-a-strong-password
 ROMM_AUTH_SECRET_KEY=replace-with-openssl-rand-hex-32
 HASHEOUS_API_ENABLED=true
 SCREENSCRAPER_USER=

--- a/apps/romm/4.9.2/data.yml
+++ b/apps/romm/4.9.2/data.yml
@@ -33,9 +33,54 @@ additionalProperties:
         pt-br: Diretório de Dados
       required: true
       type: text
+    - child:
+        default: ""
+        envKey: PANEL_DB_HOST
+        labelEn: Database Service
+        labelZh: 数据库服务
+        label:
+          en: Database Service
+          zh: 数据库服务
+          zh-Hant: 資料庫服務
+          ja: データベースサービス
+          ko: 데이터베이스 서비스
+          ru: Сервис базы данных
+          ms: Perkhidmatan Pangkalan Data
+          pt-br: Serviço de Banco de Dados
+        required: true
+        type: service
+      default: mariadb
+      envKey: PANEL_DB_TYPE
+      labelEn: Database Type
+      labelZh: 数据库类型
+      label:
+        en: Database Type
+        zh: 数据库类型
+        zh-Hant: 資料庫類型
+        ja: データベース種類
+        ko: 데이터베이스 유형
+        ru: Тип базы данных
+        ms: Jenis Pangkalan Data
+        pt-br: Tipo de Banco de Dados
+      params:
+        - envKey: PANEL_DB_PORT
+          key: mariadb
+          type: param
+          value: "3306"
+        - envKey: PANEL_DB_PORT
+          key: postgresql
+          type: param
+          value: "5432"
+      required: true
+      type: apps
+      values:
+        - label: MariaDB
+          value: mariadb
+        - label: PostgreSQL
+          value: postgresql
     - default: romm
       edit: true
-      envKey: DB_NAME
+      envKey: PANEL_DB_NAME
       labelEn: Database Name
       labelZh: 数据库名称
       label:
@@ -47,12 +92,13 @@ additionalProperties:
         ru: Имя базы данных
         ms: Nama Pangkalan Data
         pt-br: Nome do Banco de Dados
+      random: true
       required: true
       rule: paramCommon
       type: text
     - default: romm-user
       edit: true
-      envKey: DB_USER
+      envKey: PANEL_DB_USER
       labelEn: Database User
       labelZh: 数据库用户
       label:
@@ -64,12 +110,13 @@ additionalProperties:
         ru: Пользователь базы данных
         ms: Pengguna Pangkalan Data
         pt-br: Usuário do Banco de Dados
+      random: true
       required: true
       rule: paramCommon
       type: text
     - default: ""
       edit: true
-      envKey: DB_PASSWORD
+      envKey: PANEL_DB_USER_PASSWORD
       labelEn: Database Password
       labelZh: 数据库密码
       label:
@@ -81,24 +128,6 @@ additionalProperties:
         ru: Пароль базы данных
         ms: Kata Laluan Pangkalan Data
         pt-br: Senha do Banco de Dados
-      random: true
-      required: true
-      rule: paramComplexity
-      type: password
-    - default: ""
-      edit: true
-      envKey: DB_ROOT_PASSWORD
-      labelEn: Database Root Password
-      labelZh: 数据库 Root 密码
-      label:
-        en: Database Root Password
-        zh: 数据库 Root 密码
-        zh-Hant: 資料庫 Root 密碼
-        ja: データベース Root パスワード
-        ko: 데이터베이스 Root 비밀번호
-        ru: Пароль root базы данных
-        ms: Kata Laluan Root Pangkalan Data
-        pt-br: Senha Root do Banco de Dados
       random: true
       required: true
       rule: paramComplexity

--- a/apps/romm/4.9.2/docker-compose.yml
+++ b/apps/romm/4.9.2/docker-compose.yml
@@ -5,11 +5,12 @@ services:
     restart: unless-stopped
     environment:
       - TZ=${TZ}
-      - ROMM_DB_DRIVER=mariadb
-      - DB_HOST=romm-db
-      - DB_NAME=${DB_NAME}
-      - DB_USER=${DB_USER}
-      - DB_PASSWD=${DB_PASSWORD}
+      - ROMM_DB_DRIVER=${PANEL_DB_TYPE}
+      - DB_HOST=${PANEL_DB_HOST}
+      - DB_PORT=${PANEL_DB_PORT}
+      - DB_NAME=${PANEL_DB_NAME}
+      - DB_USER=${PANEL_DB_USER}
+      - DB_PASSWD=${PANEL_DB_USER_PASSWORD}
       - ROMM_AUTH_SECRET_KEY=${ROMM_AUTH_SECRET_KEY}
       - SCREENSCRAPER_USER=${SCREENSCRAPER_USER}
       - SCREENSCRAPER_PASSWORD=${SCREENSCRAPER_PASSWORD}
@@ -21,10 +22,6 @@ services:
       - "${APP_DATA_DIR}/redis:/redis-data"
     ports:
       - "${PANEL_APP_PORT_HTTP}:8080"
-    depends_on:
-      romm-db:
-        condition: service_healthy
-        restart: true
     healthcheck:
       test:
         - CMD-SHELL
@@ -32,33 +29,6 @@ services:
       start_period: 120s
       interval: 30s
       timeout: 10s
-      retries: 5
-    labels:
-      createdBy: "Apps"
-    networks:
-      - 1panel-network
-
-  romm-db:
-    image: "mariadb:11"
-    container_name: ${CONTAINER_NAME}-db
-    restart: unless-stopped
-    environment:
-      - TZ=${TZ}
-      - MARIADB_ROOT_PASSWORD=${DB_ROOT_PASSWORD}
-      - MARIADB_DATABASE=${DB_NAME}
-      - MARIADB_USER=${DB_USER}
-      - MARIADB_PASSWORD=${DB_PASSWORD}
-    volumes:
-      - "${APP_DATA_DIR}/mariadb:/var/lib/mysql"
-    healthcheck:
-      test:
-        - CMD
-        - healthcheck.sh
-        - --connect
-        - --innodb_initialized
-      start_period: 30s
-      interval: 10s
-      timeout: 5s
       retries: 5
     labels:
       createdBy: "Apps"

--- a/apps/romm/4.9.2/scripts/init.sh
+++ b/apps/romm/4.9.2/scripts/init.sh
@@ -25,8 +25,7 @@ mkdir -p \
   "$DATA_DIR/romm/assets" \
   "$DATA_DIR/romm/config" \
   "$DATA_DIR/romm/resources" \
-  "$DATA_DIR/redis" \
-  "$DATA_DIR/mariadb"
+  "$DATA_DIR/redis"
 
 chmod 755 \
   "$DATA_DIR/romm" \
@@ -36,4 +35,3 @@ chmod 755 \
   "$DATA_DIR/romm/config" \
   "$DATA_DIR/romm/resources" \
   "$DATA_DIR/redis"
-chmod 700 "$DATA_DIR/mariadb"

--- a/apps/romm/README.md
+++ b/apps/romm/README.md
@@ -9,7 +9,7 @@ RomM 是一个自托管的复古游戏库管理器。它可以扫描游戏文件
 - 管理 400 多种游戏平台的游戏库。
 - 从 ScreenScraper、RetroAchievements、SteamGridDB 和 Hasheous 获取元数据。
 - 支持浏览器游玩、存档、状态、截图、补丁和多用户权限。
-- 内置 Valkey 缓存和任务队列，使用 MariaDB 11 持久化业务数据。
+- 内置 Valkey 缓存和任务队列，支持使用 1Panel 管理的 MariaDB 或 PostgreSQL 持久化业务数据。
 
 ## 访问说明
 
@@ -17,6 +17,16 @@ RomM 是一个自托管的复古游戏库管理器。它可以扫描游戏文件
 - 容器内部端口：`8080`
 - 首次访问会进入设置向导，第一个创建的用户自动成为管理员。
 - 基础扫描不强制要求元数据服务凭据，但建议至少配置一个元数据来源。
+- 安装前需要先在 1Panel 应用商店安装并启动 MariaDB 或 PostgreSQL 服务。
+
+## 数据库选择
+
+安装表单可以选择以下 1Panel 数据库服务：
+
+- MariaDB：使用 RomM 的 `mariadb` 驱动和服务实际端口。
+- PostgreSQL：使用 RomM 的 `postgresql` 驱动和服务实际端口。
+
+1Panel 会在所选服务中创建独立的 RomM 数据库和用户，并将主机、端口、数据库名、用户名和密码注入容器。不要填写数据库服务的 root 或管理员账号作为 RomM 用户。
 
 ## 数据持久化
 
@@ -24,11 +34,10 @@ RomM 是一个自托管的复古游戏库管理器。它可以扫描游戏文件
 
 - `romm/`：游戏库、资源、上传的存档与截图以及 `config.yml`。
 - `redis/`：镜像内置 Valkey 的缓存与后台任务数据。
-- `mariadb/`：MariaDB 数据库文件。
 
 RomM 需要在部分目录之间创建硬链接，因此本适配将整个 `/romm` 挂载为同一个文件系统。游戏文件应放入 `romm/library/roms/` 下符合官方目录规范的位置。
 
-升级前建议备份整个数据目录。卸载应用不会删除绑定目录中的用户数据。
+升级前建议备份整个数据目录，并通过 1Panel 单独备份所选数据库。卸载应用不会删除绑定目录中的用户数据。
 
 ## 元数据服务
 
@@ -39,8 +48,8 @@ RomM 需要在部分目录之间创建硬链接，因此本适配将整个 `/rom
 
 ## 安全与资源说明
 
-- 安装表单会生成 MariaDB 用户密码、MariaDB root 密码和固定的 RomM 会话签名密钥。
-- 不要在升级时更换上述密码或签名密钥，否则可能导致数据库连接失败或现有登录会话失效。
+- 安装表单会生成独立数据库用户密码和固定的 RomM 会话签名密钥。
+- 不要在升级时随意更换数据库服务、密码或签名密钥，否则可能导致数据库连接失败或现有登录会话失效。
 - RomM 容器内部以 root 启动多个进程，但不需要特权模式、Docker Socket 或 host 网络。
 - 对公网开放时，建议通过 1Panel 网站反向代理启用 HTTPS。
 - 游戏文件、固件和 BIOS 可能受版权限制，请仅使用有权持有和运行的内容。
@@ -62,7 +71,8 @@ RomM is a self-hosted retro game library manager. It scans and enriches game col
 - Manage and enrich retro game libraries for more than 400 platforms.
 - Play supported games in the browser and manage saves, states, screenshots, and patches.
 - Use optional metadata providers including ScreenScraper, RetroAchievements, SteamGridDB, and Hasheous.
-- Keep application data, the built-in Valkey cache, and the MariaDB database persistent across upgrades.
+- Select a 1Panel-managed MariaDB or PostgreSQL service during installation.
+- Keep application data and the built-in Valkey cache persistent across upgrades while backing up the selected database separately.
 
 ## Links
 

--- a/apps/romm/latest/.env.sample
+++ b/apps/romm/latest/.env.sample
@@ -1,9 +1,11 @@
 PANEL_APP_PORT_HTTP=8080
 APP_DATA_DIR=./data
-DB_NAME=romm
-DB_USER=romm-user
-DB_PASSWORD=replace-with-a-strong-password
-DB_ROOT_PASSWORD=replace-with-a-different-strong-password
+PANEL_DB_TYPE=mariadb
+PANEL_DB_HOST=mariadb
+PANEL_DB_PORT=3306
+PANEL_DB_NAME=romm
+PANEL_DB_USER=romm-user
+PANEL_DB_USER_PASSWORD=replace-with-a-strong-password
 ROMM_AUTH_SECRET_KEY=replace-with-openssl-rand-hex-32
 HASHEOUS_API_ENABLED=true
 SCREENSCRAPER_USER=

--- a/apps/romm/latest/data.yml
+++ b/apps/romm/latest/data.yml
@@ -33,9 +33,54 @@ additionalProperties:
         pt-br: Diretório de Dados
       required: true
       type: text
+    - child:
+        default: ""
+        envKey: PANEL_DB_HOST
+        labelEn: Database Service
+        labelZh: 数据库服务
+        label:
+          en: Database Service
+          zh: 数据库服务
+          zh-Hant: 資料庫服務
+          ja: データベースサービス
+          ko: 데이터베이스 서비스
+          ru: Сервис базы данных
+          ms: Perkhidmatan Pangkalan Data
+          pt-br: Serviço de Banco de Dados
+        required: true
+        type: service
+      default: mariadb
+      envKey: PANEL_DB_TYPE
+      labelEn: Database Type
+      labelZh: 数据库类型
+      label:
+        en: Database Type
+        zh: 数据库类型
+        zh-Hant: 資料庫類型
+        ja: データベース種類
+        ko: 데이터베이스 유형
+        ru: Тип базы данных
+        ms: Jenis Pangkalan Data
+        pt-br: Tipo de Banco de Dados
+      params:
+        - envKey: PANEL_DB_PORT
+          key: mariadb
+          type: param
+          value: "3306"
+        - envKey: PANEL_DB_PORT
+          key: postgresql
+          type: param
+          value: "5432"
+      required: true
+      type: apps
+      values:
+        - label: MariaDB
+          value: mariadb
+        - label: PostgreSQL
+          value: postgresql
     - default: romm
       edit: true
-      envKey: DB_NAME
+      envKey: PANEL_DB_NAME
       labelEn: Database Name
       labelZh: 数据库名称
       label:
@@ -47,12 +92,13 @@ additionalProperties:
         ru: Имя базы данных
         ms: Nama Pangkalan Data
         pt-br: Nome do Banco de Dados
+      random: true
       required: true
       rule: paramCommon
       type: text
     - default: romm-user
       edit: true
-      envKey: DB_USER
+      envKey: PANEL_DB_USER
       labelEn: Database User
       labelZh: 数据库用户
       label:
@@ -64,12 +110,13 @@ additionalProperties:
         ru: Пользователь базы данных
         ms: Pengguna Pangkalan Data
         pt-br: Usuário do Banco de Dados
+      random: true
       required: true
       rule: paramCommon
       type: text
     - default: ""
       edit: true
-      envKey: DB_PASSWORD
+      envKey: PANEL_DB_USER_PASSWORD
       labelEn: Database Password
       labelZh: 数据库密码
       label:
@@ -81,24 +128,6 @@ additionalProperties:
         ru: Пароль базы данных
         ms: Kata Laluan Pangkalan Data
         pt-br: Senha do Banco de Dados
-      random: true
-      required: true
-      rule: paramComplexity
-      type: password
-    - default: ""
-      edit: true
-      envKey: DB_ROOT_PASSWORD
-      labelEn: Database Root Password
-      labelZh: 数据库 Root 密码
-      label:
-        en: Database Root Password
-        zh: 数据库 Root 密码
-        zh-Hant: 資料庫 Root 密碼
-        ja: データベース Root パスワード
-        ko: 데이터베이스 Root 비밀번호
-        ru: Пароль root базы данных
-        ms: Kata Laluan Root Pangkalan Data
-        pt-br: Senha Root do Banco de Dados
       random: true
       required: true
       rule: paramComplexity

--- a/apps/romm/latest/docker-compose.yml
+++ b/apps/romm/latest/docker-compose.yml
@@ -5,11 +5,12 @@ services:
     restart: unless-stopped
     environment:
       - TZ=${TZ}
-      - ROMM_DB_DRIVER=mariadb
-      - DB_HOST=romm-db
-      - DB_NAME=${DB_NAME}
-      - DB_USER=${DB_USER}
-      - DB_PASSWD=${DB_PASSWORD}
+      - ROMM_DB_DRIVER=${PANEL_DB_TYPE}
+      - DB_HOST=${PANEL_DB_HOST}
+      - DB_PORT=${PANEL_DB_PORT}
+      - DB_NAME=${PANEL_DB_NAME}
+      - DB_USER=${PANEL_DB_USER}
+      - DB_PASSWD=${PANEL_DB_USER_PASSWORD}
       - ROMM_AUTH_SECRET_KEY=${ROMM_AUTH_SECRET_KEY}
       - SCREENSCRAPER_USER=${SCREENSCRAPER_USER}
       - SCREENSCRAPER_PASSWORD=${SCREENSCRAPER_PASSWORD}
@@ -21,10 +22,6 @@ services:
       - "${APP_DATA_DIR}/redis:/redis-data"
     ports:
       - "${PANEL_APP_PORT_HTTP}:8080"
-    depends_on:
-      romm-db:
-        condition: service_healthy
-        restart: true
     healthcheck:
       test:
         - CMD-SHELL
@@ -32,33 +29,6 @@ services:
       start_period: 120s
       interval: 30s
       timeout: 10s
-      retries: 5
-    labels:
-      createdBy: "Apps"
-    networks:
-      - 1panel-network
-
-  romm-db:
-    image: "mariadb:11"
-    container_name: ${CONTAINER_NAME}-db
-    restart: unless-stopped
-    environment:
-      - TZ=${TZ}
-      - MARIADB_ROOT_PASSWORD=${DB_ROOT_PASSWORD}
-      - MARIADB_DATABASE=${DB_NAME}
-      - MARIADB_USER=${DB_USER}
-      - MARIADB_PASSWORD=${DB_PASSWORD}
-    volumes:
-      - "${APP_DATA_DIR}/mariadb:/var/lib/mysql"
-    healthcheck:
-      test:
-        - CMD
-        - healthcheck.sh
-        - --connect
-        - --innodb_initialized
-      start_period: 30s
-      interval: 10s
-      timeout: 5s
       retries: 5
     labels:
       createdBy: "Apps"

--- a/apps/romm/latest/scripts/init.sh
+++ b/apps/romm/latest/scripts/init.sh
@@ -25,8 +25,7 @@ mkdir -p \
   "$DATA_DIR/romm/assets" \
   "$DATA_DIR/romm/config" \
   "$DATA_DIR/romm/resources" \
-  "$DATA_DIR/redis" \
-  "$DATA_DIR/mariadb"
+  "$DATA_DIR/redis"
 
 chmod 755 \
   "$DATA_DIR/romm" \
@@ -36,4 +35,3 @@ chmod 755 \
   "$DATA_DIR/romm/config" \
   "$DATA_DIR/romm/resources" \
   "$DATA_DIR/redis"
-chmod 700 "$DATA_DIR/mariadb"


### PR DESCRIPTION
## Summary

- replace the bundled MariaDB container with native 1Panel database service selection
- support tested MariaDB and PostgreSQL services with dynamic host and port injection
- keep RomM and Valkey data persistent while database backups remain managed by 1Panel

## Verification

- `validate-v2.sh` strict validation passed for `4.9.2` and `latest` with zero warnings
- `4.9.2` installed through 1Panel with MariaDB 11.8.8, returned HTTP 200, restarted, and uninstalled cleanly
- `latest` installed through 1Panel with PostgreSQL, returned HTTP 200, restarted, and uninstalled cleanly
- MySQL was evaluated but not exposed because RomM 4.9.2 fresh migrations fail against MySQL 8.4
- no privileged mode, host network, Docker socket, or added capabilities
