### PR TITLE
Fix Renovate version selection for multi-service apps

### DIFF
--- a/.github/scripts/renovate_app_version.py
+++ b/.github/scripts/renovate_app_version.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path, PurePosixPath
+from typing import Any, NamedTuple
+
+import yaml
+
+
+class VersionSelection(NamedTuple):
+    service: str
+    version: str
+    changed_services: list[str]
+    reason: str
+
+
+def services(compose: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    raw_services = compose.get("services")
+    if not isinstance(raw_services, dict):
+        raise ValueError("compose services must be a mapping")
+    return {
+        str(name): value
+        for name, value in raw_services.items()
+        if isinstance(value, dict)
+    }
+
+
+def image_tag(image: object) -> str:
+    value = str(image or "").strip()
+    if not value or "@" in value:
+        return ""
+    slash = value.rfind("/")
+    colon = value.rfind(":")
+    if colon <= slash:
+        return ""
+    tag = value[colon + 1 :].strip()
+    return tag[1:] if tag.startswith("v") else tag
+
+
+def select_target_version(
+    app: str,
+    base_compose: dict[str, Any],
+    head_compose: dict[str, Any],
+    primary_policy: dict[str, list[str]],
+) -> VersionSelection:
+    base_services = services(base_compose)
+    head_services = services(head_compose)
+    service_names = sorted(set(base_services) | set(head_services))
+    changed = [
+        name
+        for name in service_names
+        if base_services.get(name, {}).get("image") != head_services.get(name, {}).get("image")
+    ]
+    if not changed:
+        return VersionSelection("", "", [], "no service image changed")
+
+    service_count = max(len(base_services), len(head_services))
+    if service_count == 1:
+        candidates = changed
+    else:
+        primary_services = primary_policy.get(app) or []
+        if not primary_services:
+            return VersionSelection("", "", changed, "multi-service compose has no primary service mapping")
+        candidates = [name for name in primary_services if name in changed]
+        if not candidates:
+            return VersionSelection("", "", changed, "multi-service compose changed only auxiliary services")
+
+    versions: dict[str, str] = {}
+    for service in candidates:
+        tag = image_tag(head_services.get(service, {}).get("image"))
+        if not tag:
+            raise ValueError(f"changed primary service has no usable image tag: {service}")
+        versions[service] = tag
+
+    unique_versions = sorted(set(versions.values()))
+    if len(unique_versions) != 1:
+        detail = ", ".join(f"{service}={version}" for service, version in versions.items())
+        raise ValueError(f"changed primary services have different target tags: {detail}")
+
+    return VersionSelection(candidates[0], unique_versions[0], changed, "primary service image changed")
+
+
+def load_yaml_text(text: str, label: str) -> dict[str, Any]:
+    payload = yaml.safe_load(text) or {}
+    if not isinstance(payload, dict):
+        raise ValueError(f"{label} must decode to a mapping")
+    return payload
+
+
+def git_show(ref: str, path: str) -> str:
+    result = subprocess.run(
+        ["git", "show", f"{ref}:{path}"],
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or result.stdout.strip() or f"unable to read {path} at {ref}")
+    return result.stdout
+
+
+def validate_compose_path(app: str, old_version: str, raw_path: str) -> str:
+    path = PurePosixPath(raw_path)
+    expected_parent = PurePosixPath("apps") / app / old_version
+    if path.name != "docker-compose.yml" or path.parent != expected_parent:
+        raise ValueError(f"compose path must be {expected_parent}/docker-compose.yml")
+    return path.as_posix()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Select the app version from the changed primary service image.")
+    parser.add_argument("--app", required=True)
+    parser.add_argument("--old-version", required=True)
+    parser.add_argument("--compose", required=True)
+    parser.add_argument("--base-ref", required=True)
+    parser.add_argument("--policy-file", required=True)
+    args = parser.parse_args()
+
+    compose_path = validate_compose_path(args.app, args.old_version, args.compose)
+    head_compose = load_yaml_text(Path(compose_path).read_text(encoding="utf-8"), "head compose")
+    base_compose = load_yaml_text(git_show(args.base_ref, compose_path), "base compose")
+    policy_payload = json.loads(Path(args.policy_file).read_text(encoding="utf-8"))
+    if not isinstance(policy_payload, dict):
+        raise ValueError("primary service policy must decode to an object")
+    primary_policy = {
+        str(app): [str(service) for service in configured]
+        for app, configured in policy_payload.items()
+        if isinstance(configured, list)
+    }
+
+    selection = select_target_version(args.app, base_compose, head_compose, primary_policy)
+    if not selection.version:
+        print(f"skip: {selection.reason}; changed={','.join(selection.changed_services)}", file=sys.stderr)
+        return 0
+    print(selection.version)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_renovate_app_version.py
+++ b/.github/scripts/test_renovate_app_version.py
@@ -1,0 +1,113 @@
+import importlib.util
+import json
+import pathlib
+import unittest
+
+
+SCRIPT_PATH = pathlib.Path(__file__).with_name("renovate_app_version.py")
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("renovate_app_version", SCRIPT_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"unable to load {SCRIPT_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def compose(images):
+    return {"services": {name: {"image": image} for name, image in images.items()}}
+
+
+class RenovateAppVersionTests(unittest.TestCase):
+    def test_single_service_uses_the_changed_service_tag(self):
+        module = load_module()
+
+        selection = module.select_target_version(
+            "demo",
+            compose({"app": "example/demo:1.0.0"}),
+            compose({"app": "example/demo:1.0.1"}),
+            {},
+        )
+
+        self.assertEqual("1.0.1", selection.version)
+        self.assertEqual(["app"], selection.changed_services)
+
+    def test_multi_service_sidecar_only_change_does_not_rename(self):
+        module = load_module()
+
+        selection = module.select_target_version(
+            "demo",
+            compose({"app": "example/demo:1.0.0", "db": "postgres:17.5"}),
+            compose({"app": "example/demo:1.0.0", "db": "postgres:17.6"}),
+            {"demo": ["app"]},
+        )
+
+        self.assertEqual("", selection.version)
+        self.assertEqual("multi-service compose changed only auxiliary services", selection.reason)
+
+    def test_multi_service_without_primary_mapping_does_not_use_first_service(self):
+        module = load_module()
+
+        selection = module.select_target_version(
+            "flux-panel",
+            compose(
+                {
+                    "mysql": "mysql:5.7",
+                    "backend": "bqlpfy/springboot-backend:1.4.3",
+                    "frontend": "bqlpfy/vite-frontend:1.4.3",
+                }
+            ),
+            compose(
+                {
+                    "mysql": "mysql:5.7",
+                    "backend": "bqlpfy/springboot-backend:1.4.3",
+                    "frontend": "bqlpfy/vite-frontend:v3.1.2",
+                }
+            ),
+            {},
+        )
+
+        self.assertEqual("", selection.version)
+        self.assertEqual("multi-service compose has no primary service mapping", selection.reason)
+
+    def test_multi_service_primary_change_uses_primary_tag(self):
+        module = load_module()
+
+        selection = module.select_target_version(
+            "rocketchat",
+            compose({"rocketchat": "rocket.chat:8.6.0", "mongodb": "mongodb:8.2"}),
+            compose({"rocketchat": "rocket.chat:8.6.1", "mongodb": "mongodb:8.2"}),
+            {"rocketchat": ["rocketchat"]},
+        )
+
+        self.assertEqual("8.6.1", selection.version)
+        self.assertEqual("rocketchat", selection.service)
+
+    def test_changed_primary_services_must_have_one_coordinated_tag(self):
+        module = load_module()
+
+        with self.assertRaisesRegex(ValueError, "different target tags"):
+            module.select_target_version(
+                "demo",
+                compose({"api": "example/api:1.0.0", "web": "example/web:1.0.0"}),
+                compose({"api": "example/api:2.0.0", "web": "example/web:3.0.0"}),
+                {"demo": ["api", "web"]},
+            )
+
+    def test_flux_panel_is_pinned_while_upstream_is_paused(self):
+        config = json.loads((REPO_ROOT / "renovate.json").read_text(encoding="utf-8"))
+        matching = [
+            rule
+            for rule in config.get("packageRules", [])
+            if "apps/flux-panel/**/docker-compose.yml" in rule.get("matchFileNames", [])
+        ]
+
+        self.assertTrue(matching)
+        self.assertTrue(any(rule.get("enabled") is False for rule in matching))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/renovate-app-version.sh
+++ b/.github/workflows/renovate-app-version.sh
@@ -1,11 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# This script renames a version directory to match the image tag from its compose file.
+# This script renames a version directory to match the changed primary service image tag.
 
 app_name=${1:?missing app name}
 old_version=${2:?missing source version}
+docker_compose_file=${3:?missing docker-compose path}
+base_ref=${4:?missing base ref}
 source_dir="apps/$app_name/$old_version"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+policy_file="$script_dir/../renovate-primary-services.json"
+selector="$script_dir/../scripts/renovate_app_version.py"
 
 case "$old_version" in
   latest|stable)
@@ -19,32 +24,22 @@ if [[ ! -d "$source_dir" ]]; then
   exit 0
 fi
 
-# Find all docker-compose files under apps/$app_name/$old_version (there should be only one).
-docker_compose_files=$(find "$source_dir" -name docker-compose.yml)
+trimmed_version=$(python3 "$selector" \
+  --app "$app_name" \
+  --old-version "$old_version" \
+  --compose "$docker_compose_file" \
+  --base-ref "$base_ref" \
+  --policy-file "$policy_file")
 
-for docker_compose_file in $docker_compose_files; do
-  # Assume the app version comes from the first service image.
-  first_service=$(yq '.services | keys | .[0]' "$docker_compose_file")
-  image=$(yq ".services.${first_service}.image" "$docker_compose_file")
+if [[ -z "$trimmed_version" || "$trimmed_version" == "$old_version" ]]; then
+  echo "skip: $source_dir already matches the selected primary image tag"
+  exit 0
+fi
 
-  # Only apply changes if the format is <image>:<version>.
-  if [[ "$image" != *":"* ]]; then
-    continue
-  fi
+target_dir="apps/$app_name/$trimmed_version"
+if [[ -e "$target_dir" ]]; then
+  echo "target already exists: $target_dir" >&2
+  exit 1
+fi
 
-  version=$(cut -d ":" -f2- <<< "$image")
-  trimmed_version=${version/#"v"}
-
-  if [[ -z "$trimmed_version" || "$trimmed_version" == "$old_version" ]]; then
-    echo "skip: $source_dir already matches image tag $version"
-    continue
-  fi
-
-  target_dir="apps/$app_name/$trimmed_version"
-  if [[ -e "$target_dir" ]]; then
-    echo "target already exists: $target_dir" >&2
-    exit 1
-  fi
-
-  mv "$source_dir" "$target_dir"
-done
+mv "$source_dir" "$target_dir"

--- a/.github/workflows/renovate-app-version.yml
+++ b/.github/workflows/renovate-app-version.yml
@@ -26,7 +26,12 @@ jobs:
       - name: Get list of updated files by the last commit in this branch separated by space
         id: updated-files
         run: |
-          echo "files=$(git diff-tree --no-commit-id --name-only -r ${{ github.sha }} | tr '\n' ' ')" >> "$GITHUB_OUTPUT"
+          base_ref="${{ github.event.before }}"
+          if [[ -z "$base_ref" || "$base_ref" =~ ^0+$ ]]; then
+            base_ref="HEAD^"
+          fi
+          echo "base_ref=$base_ref" >> "$GITHUB_OUTPUT"
+          echo "files=$(git diff --name-only "$base_ref" "${{ github.sha }}" | tr '\n' ' ')" >> "$GITHUB_OUTPUT"
 
       - name: Run renovate-app-version.sh on updated files
         run: |
@@ -37,7 +42,11 @@ jobs:
               app_name=$(echo "$file" | cut -d'/' -f 2)
               old_version=$(echo "$file" | cut -d'/' -f 3)
               chmod +x .github/workflows/renovate-app-version.sh
-              .github/workflows/renovate-app-version.sh "$app_name" "$old_version"
+              .github/workflows/renovate-app-version.sh \
+                "$app_name" \
+                "$old_version" \
+                "$file" \
+                "${{ steps.updated-files.outputs.base_ref }}"
             fi
           done
 

--- a/renovate.json
+++ b/renovate.json
@@ -374,6 +374,13 @@
       "allowedVersions": "/^17.*/"
     },
     {
+      "description": "Keep Flux Panel on upstream stable 1.4.3 while the project is paused",
+      "matchFileNames": [
+        "apps/flux-panel/**/docker-compose.yml"
+      ],
+      "enabled": false
+    },
+    {
       "description": "Disable sidecar-only Renovate updates for ClearFlask multi-service tracks",
       "matchFileNames": [
         "apps/clearflask/**/docker-compose.yml"


### PR DESCRIPTION
## Summary

- stop deriving app directory versions from the first compose service
- for single-service apps, use the only changed service image tag
- for multi-service apps, use only changed services declared in `.github/renovate-primary-services.json`
- skip sidecar-only or unmapped multi-service updates instead of renaming to a database tag
- pin Flux Panel to upstream stable `1.4.3` while the project remains paused

This prevents PRs such as #4723 and #4724 from renaming `apps/flux-panel/1.4.3` to `5.7` because MySQL is the first compose service.

## Verification

- `python3 .github/scripts/test_renovate_app_version.py`
- `ruff check .github/scripts/renovate_app_version.py .github/scripts/test_renovate_app_version.py .github/scripts/renovate_sidecar_guard.py`
- `shellcheck .github/workflows/renovate-app-version.sh`
- `actionlint .github/workflows/renovate-app-version.yml .github/workflows/renovate-sidecar-guard.yml`
- `jq empty renovate.json .github/renovate-primary-services.json`