### PR TITLE
Fix self-hosted Renovate repository target

### DIFF
--- a/.github/scripts/test_renovate_app_version.py
+++ b/.github/scripts/test_renovate_app_version.py
@@ -108,6 +108,11 @@ class RenovateAppVersionTests(unittest.TestCase):
         self.assertTrue(matching)
         self.assertTrue(any(rule.get("enabled") is False for rule in matching))
 
+    def test_self_hosted_renovate_targets_this_repository(self):
+        workflow = (REPO_ROOT / ".github" / "workflows" / "renovate.yml").read_text(encoding="utf-8")
+
+        self.assertIn("RENOVATE_REPOSITORIES: ${{ github.repository }}", workflow)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -22,3 +22,5 @@ jobs:
         uses: renovatebot/github-action@b50d2ba2bd928235abdcc14d06dfafc217f1c565 # v46.1.18
         with:
           token: ${{ secrets.GITHUBTOKEN }}
+        env:
+          RENOVATE_REPOSITORIES: ${{ github.repository }}


### PR DESCRIPTION
## Summary

The self-hosted Renovate action had a token and repository config file, but no self-hosted `repositories` target. Every run therefore concluded green while logging:

```text
WARN: No repositories found - did you want to run with flag --autodiscover?
```

Set `RENOVATE_REPOSITORIES: ${{ github.repository }}` so the action scans this repository explicitly. This follows the pinned `renovatebot/github-action` documentation, where self-hosted configuration must provide `repositories` or autodiscovery.

## Verification

- regression assertion in `.github/scripts/test_renovate_app_version.py`
- `python3 .github/scripts/test_renovate_app_version.py`
- `actionlint .github/workflows/renovate.yml`
- semantic audit reproduced the failure on run `29160243071` for exact head SHA `305513a4e9adb66a1465ba4c22e7366231d9a9ec`