### PR TITLE
Fail incomplete Renovate runs

### DIFF
--- a/.github/scripts/renovate-entrypoint.sh
+++ b/.github/scripts/renovate-entrypoint.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+log_file="$(mktemp -t renovate-output.XXXXXX)"
+trap 'rm -f "$log_file"' EXIT
+
+set +e
+renovate "$@" 2>&1 | tee "$log_file"
+renovate_status=${PIPESTATUS[0]}
+set -e
+
+if grep -Eiq 'External host error causing abort|"result"[[:space:]]*:[[:space:]]*"external-host-error"' "$log_file"; then
+  echo "Renovate aborted because an external host failed; dependency processing is incomplete." >&2
+  exit 1
+fi
+
+exit "$renovate_status"

--- a/.github/scripts/test_renovate_app_version.py
+++ b/.github/scripts/test_renovate_app_version.py
@@ -1,6 +1,9 @@
 import importlib.util
 import json
+import os
 import pathlib
+import subprocess
+import tempfile
 import unittest
 
 
@@ -112,6 +115,56 @@ class RenovateAppVersionTests(unittest.TestCase):
         workflow = (REPO_ROOT / ".github" / "workflows" / "renovate.yml").read_text(encoding="utf-8")
 
         self.assertIn("RENOVATE_REPOSITORIES: ${{ github.repository }}", workflow)
+
+    def test_self_hosted_renovate_uses_semantic_entrypoint(self):
+        workflow = (REPO_ROOT / ".github" / "workflows" / "renovate.yml").read_text(encoding="utf-8")
+
+        self.assertIn("docker-cmd-file: .github/scripts/renovate-entrypoint.sh", workflow)
+
+    def test_semantic_entrypoint_blocks_external_host_abort(self):
+        entrypoint = REPO_ROOT / ".github" / "scripts" / "renovate-entrypoint.sh"
+        with tempfile.TemporaryDirectory(prefix="renovate-entrypoint-test-") as tmp:
+            fake_renovate = pathlib.Path(tmp) / "renovate"
+            fake_renovate.write_text(
+                "#!/usr/bin/env bash\n"
+                "echo 'INFO: External host error causing abort - skipping'\n"
+                "echo '\"result\": \"external-host-error\"'\n",
+                encoding="utf-8",
+            )
+            fake_renovate.chmod(0o755)
+            env = os.environ.copy()
+            env["PATH"] = f"{tmp}:{env['PATH']}"
+
+            result = subprocess.run(["bash", str(entrypoint)], text=True, capture_output=True, env=env, check=False)
+
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn("Renovate aborted because an external host failed", result.stderr)
+
+    def test_semantic_entrypoint_preserves_clean_success(self):
+        entrypoint = REPO_ROOT / ".github" / "scripts" / "renovate-entrypoint.sh"
+        with tempfile.TemporaryDirectory(prefix="renovate-entrypoint-test-") as tmp:
+            fake_renovate = pathlib.Path(tmp) / "renovate"
+            fake_renovate.write_text("#!/usr/bin/env bash\necho 'Repository finished'\n", encoding="utf-8")
+            fake_renovate.chmod(0o755)
+            env = os.environ.copy()
+            env["PATH"] = f"{tmp}:{env['PATH']}"
+
+            result = subprocess.run(["bash", str(entrypoint)], text=True, capture_output=True, env=env, check=False)
+
+        self.assertEqual(0, result.returncode)
+
+    def test_semantic_entrypoint_preserves_renovate_failure(self):
+        entrypoint = REPO_ROOT / ".github" / "scripts" / "renovate-entrypoint.sh"
+        with tempfile.TemporaryDirectory(prefix="renovate-entrypoint-test-") as tmp:
+            fake_renovate = pathlib.Path(tmp) / "renovate"
+            fake_renovate.write_text("#!/usr/bin/env bash\necho 'ordinary failure'\nexit 23\n", encoding="utf-8")
+            fake_renovate.chmod(0o755)
+            env = os.environ.copy()
+            env["PATH"] = f"{tmp}:{env['PATH']}"
+
+            result = subprocess.run(["bash", str(entrypoint)], text=True, capture_output=True, env=env, check=False)
+
+        self.assertEqual(23, result.returncode)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -21,6 +21,7 @@ jobs:
       - name: Run Renovate
         uses: renovatebot/github-action@b50d2ba2bd928235abdcc14d06dfafc217f1c565 # v46.1.18
         with:
+          docker-cmd-file: .github/scripts/renovate-entrypoint.sh
           token: ${{ secrets.GITHUBTOKEN }}
         env:
           RENOVATE_REPOSITORIES: ${{ github.repository }}


### PR DESCRIPTION
## Summary

- run self-hosted Renovate through a repository-owned semantic entrypoint
- fail the workflow when Renovate reports an external-host abort despite exiting zero
- preserve normal success and non-zero Renovate exit codes

## Why

Run 29160756733 concluded green even though Docker Hub returned `429` and Renovate finished with `result: external-host-error`. That incomplete dependency scan must not be reported as successful.

## Verification

- `python3 .github/scripts/test_renovate_app_version.py` (11 tests)
- `bash -n .github/scripts/renovate-entrypoint.sh`
- `shellcheck .github/scripts/renovate-entrypoint.sh`
- `actionlint .github/workflows/renovate.yml`
- `git diff --check`