### PR TITLE
Explain missing Renovate registry auth

### DIFF
--- a/.github/scripts/test_renovate_app_version.py
+++ b/.github/scripts/test_renovate_app_version.py
@@ -127,6 +127,8 @@ class RenovateAppVersionTests(unittest.TestCase):
         self.assertIn("configurationFile: .github/renovate-global.js", workflow)
         self.assertIn("RENOVATE_DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}", workflow)
         self.assertIn("RENOVATE_DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}", workflow)
+        self.assertIn("name: Check Docker Hub credentials", workflow)
+        self.assertIn("Configure DOCKERHUB_USERNAME and DOCKERHUB_TOKEN repository secrets", workflow)
 
     def test_global_config_fails_fast_without_docker_hub_credentials(self):
         config = REPO_ROOT / ".github" / "renovate-global.js"

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -18,6 +18,15 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Check Docker Hub credentials
+        env:
+          RENOVATE_DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+          RENOVATE_DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+        run: |
+          if [[ -z "${RENOVATE_DOCKERHUB_USERNAME:-}" || -z "${RENOVATE_DOCKERHUB_TOKEN:-}" ]]; then
+            echo "::error::Configure DOCKERHUB_USERNAME and DOCKERHUB_TOKEN repository secrets before running Renovate."
+            exit 1
+          fi
       - name: Run Renovate
         uses: renovatebot/github-action@b50d2ba2bd928235abdcc14d06dfafc217f1c565 # v46.1.18
         with:


### PR DESCRIPTION
## Summary

- check Docker Hub credential secrets before starting the Renovate container
- emit an actionable GitHub Actions error instead of a generic config parse failure
- keep the config-level validation as defense in depth

## Verification

- `python3 .github/scripts/test_renovate_app_version.py` (14 tests)
- `node --check .github/renovate-global.js`
- `bash -n .github/scripts/renovate-entrypoint.sh`
- `shellcheck .github/scripts/renovate-entrypoint.sh`
- `actionlint .github/workflows/renovate.yml`
- `git diff --check`