### PR TITLE
Reduce full Renovate scan frequency

### DIFF
--- a/.github/scripts/test_renovate_app_version.py
+++ b/.github/scripts/test_renovate_app_version.py
@@ -116,6 +116,18 @@ class RenovateAppVersionTests(unittest.TestCase):
 
         self.assertIn("RENOVATE_REPOSITORIES: ${{ github.repository }}", workflow)
 
+    def test_full_renovate_scan_is_scheduled_or_manual_only(self):
+        workflow = (REPO_ROOT / ".github" / "workflows" / "renovate.yml").read_text(encoding="utf-8")
+
+        self.assertNotIn("  push:\n", workflow)
+        self.assertIn('    - cron: "0 0 * * *"', workflow)
+        self.assertIn("  workflow_dispatch:", workflow)
+
+    def test_full_renovate_scan_does_not_overlap(self):
+        workflow = (REPO_ROOT / ".github" / "workflows" / "renovate.yml").read_text(encoding="utf-8")
+
+        self.assertIn("concurrency:\n  group: renovate-full-scan\n  cancel-in-progress: true", workflow)
+
     def test_self_hosted_renovate_uses_semantic_entrypoint(self):
         workflow = (REPO_ROOT / ".github" / "workflows" / "renovate.yml").read_text(encoding="utf-8")
 

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -3,14 +3,15 @@ name: Renovate
 on:
   schedule:
     - cron: "0 0 * * *"
-  push:
-    branches:
-      - localApps
   workflow_dispatch:
     inputs:
       manual-trigger:
         description: 'Manually trigger Renovate'
         default: ''
+
+concurrency:
+  group: renovate-full-scan
+  cancel-in-progress: true
 
 jobs:
   renovate:


### PR DESCRIPTION
## Summary

- stop running a full 1,305-dependency scan after every `localApps` push
- keep the daily schedule and manual dispatch
- cancel an older full scan when a newer one is started

## Why

Full scans after every merge multiply Docker Hub registry requests as the application catalog grows. Daily/manual scans plus single-run concurrency preserve update coverage without repeatedly consuming registry quota.

## Verification

- `python3 .github/scripts/test_renovate_app_version.py` (16 tests)
- `node --check .github/renovate-global.js`
- `bash -n .github/scripts/renovate-entrypoint.sh`
- `shellcheck .github/scripts/renovate-entrypoint.sh`
- `actionlint .github/workflows/renovate.yml`
- `git diff --check`