### PR TITLE
Recognize self-hosted Renovate PRs

### DIFF
--- a/.github/scripts/test_renovate_app_version.py
+++ b/.github/scripts/test_renovate_app_version.py
@@ -169,6 +169,21 @@ class RenovateAppVersionTests(unittest.TestCase):
         self.assertEqual("renovate-user", host_rule["username"])
         self.assertEqual("test-token", host_rule["password"])
 
+    def test_self_hosted_renovate_branches_are_recognized_by_workflows(self):
+        workflows = REPO_ROOT / ".github" / "workflows"
+        app_version = (workflows / "renovate-app-version.yml").read_text(encoding="utf-8")
+        sidecar_guard = (workflows / "renovate-sidecar-guard.yml").read_text(encoding="utf-8")
+        automerge = (workflows / "renovate-automerge.yml").read_text(encoding="utf-8")
+        reconcile = (workflows / "renovate-automerge-reconcile.yml").read_text(encoding="utf-8")
+        labeling = (workflows / "label-third-party-prs.yml").read_text(encoding="utf-8")
+
+        self.assertIn("startsWith(github.ref_name, 'renovate/')", app_version)
+        for workflow in (sidecar_guard, automerge, labeling):
+            self.assertIn("github.event.pull_request.head.repo.full_name == github.repository", workflow)
+            self.assertIn("startsWith(github.event.pull_request.head.ref, 'renovate/')", workflow)
+        self.assertIn("headRefName,headRepositoryOwner,isCrossRepository", reconcile)
+        self.assertIn('.headRefName | startswith("renovate/")', reconcile)
+
     def test_semantic_entrypoint_blocks_external_host_abort(self):
         entrypoint = REPO_ROOT / ".github" / "scripts" / "renovate-entrypoint.sh"
         with tempfile.TemporaryDirectory(prefix="renovate-entrypoint-test-") as tmp:

--- a/.github/workflows/label-third-party-prs.yml
+++ b/.github/workflows/label-third-party-prs.yml
@@ -11,7 +11,13 @@ permissions:
 
 jobs:
   add-pending-label:
-    if: github.event.pull_request.user.login != 'app/renovate' && github.event.pull_request.user.login != 'renovate[bot]'
+    if: >
+      github.event.pull_request.user.login != 'app/renovate' &&
+      github.event.pull_request.user.login != 'renovate[bot]' &&
+      !(
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        startsWith(github.event.pull_request.head.ref, 'renovate/')
+      )
     runs-on: ubuntu-latest
     steps:
       - name: Add pending label to third-party PRs

--- a/.github/workflows/renovate-app-version.yml
+++ b/.github/workflows/renovate-app-version.yml
@@ -10,7 +10,7 @@ on:
         default: ''
 jobs:
   update-app-version:
-    if: github.event_name == 'workflow_dispatch' || github.actor == 'renovate[bot]'
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref_name, 'renovate/')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/renovate-automerge-reconcile.yml
+++ b/.github/workflows/renovate-automerge-reconcile.yml
@@ -36,9 +36,13 @@ jobs:
 
           mapfile -t pr_numbers < <(
             gh pr list --repo "$REPO" --state open --limit 100 \
-              --json number,author,labels,isDraft,baseRefName \
+              --json number,author,labels,isDraft,baseRefName,headRefName,headRepositoryOwner,isCrossRepository \
               --jq '.[]
-                | select(.author.login == "app/renovate" or .author.login == "renovate[bot]")
+                | select(
+                    .author.login == "app/renovate" or
+                    .author.login == "renovate[bot]" or
+                    ((.isCrossRepository | not) and (.headRefName | startswith("renovate/")))
+                  )
                 | select(.isDraft | not)
                 | select(.baseRefName == "localApps")
                 | select(([.labels[].name] | index("renovate-auto")) | not)

--- a/.github/workflows/renovate-automerge.yml
+++ b/.github/workflows/renovate-automerge.yml
@@ -28,7 +28,11 @@ jobs:
         github.event.pull_request.state == 'open' &&
         (
           github.event.pull_request.user.login == 'app/renovate' ||
-          github.event.pull_request.user.login == 'renovate[bot]'
+          github.event.pull_request.user.login == 'renovate[bot]' ||
+          (
+            github.event.pull_request.head.repo.full_name == github.repository &&
+            startsWith(github.event.pull_request.head.ref, 'renovate/')
+          )
         )
       ) || (
         github.event_name == 'workflow_dispatch'

--- a/.github/workflows/renovate-sidecar-guard.yml
+++ b/.github/workflows/renovate-sidecar-guard.yml
@@ -24,7 +24,11 @@ jobs:
         github.event.pull_request.state == 'open' &&
         (
           github.event.pull_request.user.login == 'app/renovate' ||
-          github.event.pull_request.user.login == 'renovate[bot]'
+          github.event.pull_request.user.login == 'renovate[bot]' ||
+          (
+            github.event.pull_request.head.repo.full_name == github.repository &&
+            startsWith(github.event.pull_request.head.ref, 'renovate/')
+          )
         )
       ) || (
         github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
## Summary

- recognize same-repository `renovate/*` branches created through the maintainer PAT
- restore app-version normalization, sidecar guard, automerge, and reconcile handling
- prevent internal Renovate PRs from receiving the third-party `pending` label
- retain official Renovate bot identity support

## Security boundary

PR write workflows accept branch-based identity only when the head branch belongs to this repository. A fork cannot gain Renovate treatment merely by naming its branch `renovate/*`.

## Verification

- `python3 .github/scripts/test_renovate_app_version.py` (17 tests)
- `actionlint` on all five changed workflows
- `shellcheck .github/workflows/renovate-app-version.sh`
- `git diff --check`