### PR TITLE
Harden Renovate application tracks

### DIFF
--- a/.github/scripts/test_renovate_app_version.py
+++ b/.github/scripts/test_renovate_app_version.py
@@ -111,6 +111,54 @@ class RenovateAppVersionTests(unittest.TestCase):
         self.assertTrue(matching)
         self.assertTrue(any(rule.get("enabled") is False for rule in matching))
 
+    def test_multi_service_application_images_are_grouped(self):
+        config = json.loads((REPO_ROOT / "renovate.json").read_text(encoding="utf-8"))
+        groups = {rule.get("groupName"): set(rule.get("matchPackageNames", [])) for rule in config.get("packageRules", []) if rule.get("groupName")}
+
+        self.assertEqual(
+            {
+                "docker.elastic.co/elasticsearch/elasticsearch",
+                "docker.elastic.co/kibana/kibana",
+            },
+            groups["Kibana application images"],
+        )
+        self.assertEqual(
+            {
+                "ghcr.io/clearflask/clearflask-connect",
+                "ghcr.io/clearflask/clearflask-server",
+            },
+            groups["ClearFlask application images"],
+        )
+
+    def test_historical_tracks_and_known_sidecars_are_not_renovated(self):
+        config = json.loads((REPO_ROOT / "renovate.json").read_text(encoding="utf-8"))
+        disabled = [rule for rule in config.get("packageRules", []) if rule.get("enabled") is False]
+
+        disabled_paths = {path for rule in disabled for path in rule.get("matchFileNames", [])}
+        self.assertTrue(
+            {
+                "apps/geekbench/4/**",
+                "apps/geekbench/5/**",
+                "apps/headscale/0.23.0-alpha3/**",
+                "apps/headscale/0.26.1/**",
+                "apps/mysql/5.5.62/**",
+            }.issubset(disabled_paths)
+        )
+        self.assertTrue(
+            any(
+                "apps/*-linuxserver/**/docker-compose.yml" in rule.get("matchFileNames", [])
+                and {"mariadb", "mongo"}.issubset(set(rule.get("matchPackageNames", [])))
+                for rule in disabled
+            )
+        )
+        self.assertTrue(
+            any(
+                "apps/traccar/**/docker-compose.yml" in rule.get("matchFileNames", [])
+                and "mysql" in rule.get("matchPackageNames", [])
+                for rule in disabled
+            )
+        )
+
     def test_self_hosted_renovate_targets_this_repository(self):
         workflow = (REPO_ROOT / ".github" / "workflows" / "renovate.yml").read_text(encoding="utf-8")
 

--- a/renovate.json
+++ b/renovate.json
@@ -374,6 +374,70 @@
       "allowedVersions": "/^17.*/"
     },
     {
+      "description": "Keep historical application tracks immutable",
+      "matchFileNames": [
+        "apps/geekbench/4/**",
+        "apps/geekbench/5/**",
+        "apps/headscale/0.23.0-alpha3/**",
+        "apps/headscale/0.26.1/**",
+        "apps/mysql/5.5.62/**"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "Group Kibana and Elasticsearch application images",
+      "matchFileNames": [
+        "apps/kibana/**/docker-compose.yml"
+      ],
+      "matchPackageNames": [
+        "docker.elastic.co/elasticsearch/elasticsearch",
+        "docker.elastic.co/kibana/kibana"
+      ],
+      "groupName": "Kibana application images"
+    },
+    {
+      "description": "Group ClearFlask application images",
+      "matchFileNames": [
+        "apps/clearflask/**/docker-compose.yml"
+      ],
+      "matchPackageNames": [
+        "ghcr.io/clearflask/clearflask-connect",
+        "ghcr.io/clearflask/clearflask-server"
+      ],
+      "groupName": "ClearFlask application images"
+    },
+    {
+      "description": "Disable bundled database-only updates for LinuxServer multi-service apps",
+      "matchFileNames": [
+        "apps/*-linuxserver/**/docker-compose.yml"
+      ],
+      "matchPackageNames": [
+        "mariadb",
+        "mongo"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "Disable bundled MongoDB-only updates for Overleaf",
+      "matchFileNames": [
+        "apps/overleaf/**/docker-compose.yml"
+      ],
+      "matchPackageNames": [
+        "mongo"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "Disable bundled MySQL-only updates for Traccar",
+      "matchFileNames": [
+        "apps/traccar/**/docker-compose.yml"
+      ],
+      "matchPackageNames": [
+        "mysql"
+      ],
+      "enabled": false
+    },
+    {
       "description": "Keep Flux Panel on upstream stable 1.4.3 while the project is paused",
       "matchFileNames": [
         "apps/flux-panel/**/docker-compose.yml"


### PR DESCRIPTION
## Summary

- group Kibana with Elasticsearch and both ClearFlask application images
- freeze historical Geekbench, Headscale, and MySQL package directories
- suppress known bundled MariaDB, MongoDB, and MySQL sidecar-only updates
- add regression coverage for grouping and immutable tracks

## Why

The authenticated full scan exposed invalid updates that replaced images inside historical version directories and split coordinated multi-service releases into separate PRs.

## Verification

- `python3 .github/scripts/test_renovate_app_version.py` (19 tests)
- `jq empty renovate.json`
- `actionlint .github/workflows/*.yml`
- `git diff --check`

A local Renovate config validator is not installed; schema behavior will also be exercised by the next authenticated manual run.