### PR TITLE
Make Mend primary for Compose updates

### DIFF
--- a/.github/renovate-controller-policy.md
+++ b/.github/renovate-controller-policy.md
@@ -1,21 +1,21 @@
 # Renovate Controller Policy
 
-This repository intentionally uses two Renovate controllers with disjoint ownership.
+This repository uses Mend Renovate for update discovery and a read-only self-hosted Compose audit.
 
 | Controller | Configuration | Managers | Branch prefix | Dashboard |
 | --- | --- | --- | --- | --- |
-| Mend Renovate App | `renovate.json` | `github-actions` | `renovate/` | `Dependency Dashboard` |
-| GitHub Actions self-hosted Renovate | `.github/renovate-global.js` and `.github/renovate-docker.json` | `docker-compose` | `selfhosted-renovate/` | `Dependency Dashboard (Docker Images)` |
+| Mend Renovate App | `renovate.json`, extending `.github/renovate-docker.json` | `github-actions`, `docker-compose` | `renovate/` | `Dependency Dashboard` |
+| GitHub Actions self-hosted audit | `.github/renovate-global.js` and `.github/renovate-docker.json` | `docker-compose` in `lookup` dry-run mode | none created | none created |
 
-The self-hosted controller sets `requireConfig: "ignored"` so the hosted controller's root configuration cannot replace its Compose-only manager scope. Do not remove this boundary or merge the two configuration files.
+The self-hosted audit sets `requireConfig: "ignored"` so the hosted root configuration cannot expand its scope. It runs on the 1st and 15th of each month with `RENOVATE_DRY_RUN=lookup`, a read-only workflow token, and no ability to create branches or PRs. Do not turn it back into a second write-capable Compose controller.
 
 ## Ownership invariants
 
-1. The controllers must not share an enabled manager.
-2. The controllers must not share a branch prefix.
-3. The controllers must not share a dashboard title.
-4. App versioning, sidecar guards, and app automerge workflows must recognize `selfhosted-renovate/` branches.
-5. Do not split the Compose catalog across concurrent Renovate instances unless each instance also has an exclusive branch namespace and cleanup scope. Directory-only sharding is insufficient because one instance can close another instance's branches and PRs.
+1. Mend is the only controller allowed to create Compose update branches and PRs.
+2. The self-hosted audit must retain `RENOVATE_DRY_RUN=lookup` and a read-only workflow token.
+3. `.github/renovate-docker.json` is the shared Compose policy source; Mend imports it as a repository preset.
+4. App versioning, sidecar guards, and app automerge workflows continue recognizing `selfhosted-renovate/` branches until all historical branches are gone.
+5. Do not split the Compose catalog across concurrent write-capable Renovate instances. Directory-only sharding is insufficient because one instance can close another instance's branches and PRs.
 
 These rules follow Renovate's documented manager allowlist, branch ownership, dashboard title, and repository-config behavior:
 
@@ -29,17 +29,17 @@ These rules follow Renovate's documented manager allowlist, branch ownership, da
 For a growing app catalog, apply capacity improvements in this order:
 
 1. Authenticate high-volume registries, especially Docker Hub.
-2. Keep manager ownership disjoint so the same dependency is not queried twice.
-3. Run the full Compose scan on a schedule or manually, with workflow concurrency preventing overlap.
+2. Keep write ownership exclusive to Mend; the twice-monthly self-hosted query is audit-only.
+3. Let Mend perform routine Compose discovery; run the self-hosted read-only audit only twice monthly or manually for diagnosis.
 4. Suppress historical tracks and auxiliary-only updates in `.github/renovate-docker.json`.
 5. Group application images that must move together and keep multi-service updates under tested maintainer review.
-6. Persist the self-hosted cache with the SHA-pinned `actions/cache` step in `.github/workflows/renovate.yml`.
+6. Persist the self-hosted audit cache with the SHA-pinned `actions/cache` step in `.github/workflows/renovate.yml`.
 
 ## Docker Hub 429 retry policy
 
-`.github/workflows/renovate-rate-limit-retry.yml` checks the latest full Renovate run once per hour. It dispatches another full scan only when the latest run is a completed failure whose logs explicitly contain a registry `429`, the failure is at least 55 minutes old, and fewer than six full scans were started that UTC day. Successful, incomplete, unrelated, and young failures are not retried.
+`.github/workflows/renovate-rate-limit-retry.yml` checks the latest self-hosted audit once per hour. It dispatches another read-only audit only when the latest run is a completed failure whose logs explicitly contain a registry `429`, the failure is at least 55 minutes old, and fewer than six audits were started that UTC day. Successful, incomplete, unrelated, and young failures are not retried.
 
-The retry controller does not keep a runner sleeping during Docker Hub's cooldown. The newly dispatched run becomes the latest run immediately, so later checks stop until that run completes. The daily cap bounds repeated registry failures.
+The retry controller does not keep a runner sleeping during Docker Hub's cooldown. The newly dispatched audit becomes the latest run immediately, so later checks stop until that run completes. The daily cap bounds repeated registry failures.
 
 ## Multi-service update policy
 
@@ -47,7 +47,7 @@ Renovate cannot natively express a dependency rule where an auxiliary image may 
 
 This is post-creation suppression, not a guarantee that Renovate never creates a temporary branch or PR. Continue disabling known auxiliary packages in `.github/renovate-docker.json` where a stable path/package rule is available. Single-service apps using the same image name are unaffected because those rules and the runtime guard are scoped by app path and Compose service count.
 
-The workflow stores Renovate's public package lookup cache and repository extraction cache under `/tmp/renovate-cache`. Private package caching remains disabled. Cache writes come only from the scheduled or manually dispatched trusted workflow.
+The audit workflow stores Renovate's public package lookup cache and repository extraction cache under `/tmp/renovate-cache`. Private package caching remains disabled. Cache writes come only from the scheduled or manually dispatched trusted workflow.
 
 GitHub Actions cache entries are immutable, so each run uses a unique key and restores the newest compatible prefix. The configuration hash separates policy generations, while the broader fallback retains public package lookup data after policy changes. Monitor the reported directory size and repository cache inventory to avoid churn against GitHub's default cache quota.
 
@@ -59,7 +59,7 @@ Restore and save are separate steps. A failed registry scan may still save valid
 - Keep `RENOVATE_CACHE_PRIVATE_PACKAGES` set to `false`.
 - Keep cache writes limited to this scheduled/manual workflow; do not add `pull_request` or `pull_request_target` triggers.
 - Keep `actions/cache` pinned to a reviewed commit SHA.
-- Keep the workflow's default `GITHUB_TOKEN` read-only. Renovate writes through the dedicated `GITHUBTOKEN` secret.
+- Keep the workflow's default `GITHUB_TOKEN` read-only. The audit must not use the write-capable `GITHUBTOKEN` secret.
 - Keep a bounded job timeout so a stalled registry cannot consume a runner indefinitely.
 - The restored directory contains Renovate data, not executable project scripts. Do not add cached paths to `PATH`, source files from them, or execute binaries restored from the cache.
 - A cache miss or corrupt entry must degrade to a fresh lookup. It must not bypass Renovate validation, sidecar guards, app-version checks, or maintainer review.
@@ -79,4 +79,4 @@ Before a full scan, verify that Docker Hub accepts the configured repository sec
 gh workflow run renovate-dockerhub-preflight.yml --ref localApps
 ```
 
-Validate both JSON configurations with the Renovate version used by `.github/workflows/renovate.yml`, then run the self-hosted workflow manually. Confirm that its log lists only `docker-compose`, its branches start with `selfhosted-renovate/`, and the hosted App does not close them before retiring an older duplicate dashboard.
+Validate both JSON configurations with the Renovate version used by `.github/workflows/renovate.yml`, then run the self-hosted workflow manually. Confirm that its log lists only `docker-compose`, reports dry-run lookup mode, and creates no branch, PR, or dashboard. Confirm separately that Mend reads both `github-actions` and `docker-compose` from `renovate.json`.

--- a/.github/scripts/test_renovate_app_version.py
+++ b/.github/scripts/test_renovate_app_version.py
@@ -11,6 +11,7 @@ SCRIPT_PATH = pathlib.Path(__file__).with_name("renovate_app_version.py")
 RETRY_SCRIPT_PATH = pathlib.Path(__file__).with_name("renovate_retry_gate.py")
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
 DOCKER_CONFIG = REPO_ROOT / ".github" / "renovate-docker.json"
+HOSTED_CONFIG = REPO_ROOT / "renovate.json"
 
 
 def load_module():
@@ -36,6 +37,25 @@ def compose(images):
 
 
 class RenovateAppVersionTests(unittest.TestCase):
+    def test_mend_is_primary_for_actions_and_compose_updates(self):
+        config = json.loads(HOSTED_CONFIG.read_text(encoding="utf-8"))
+
+        self.assertEqual({"github-actions", "docker-compose"}, set(config["enabledManagers"]))
+        self.assertIn(
+            "github>okxlin/appstore//.github/renovate-docker.json",
+            config["extends"],
+        )
+
+    def test_self_hosted_compose_scan_is_semimonthly_read_only_audit(self):
+        workflow = (REPO_ROOT / ".github" / "workflows" / "renovate.yml").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn('cron: "23 3 1,15 * *"', workflow)
+        self.assertIn("RENOVATE_DRY_RUN: lookup", workflow)
+        self.assertIn("token: ${{ github.token }}", workflow)
+        self.assertNotIn("token: ${{ secrets.GITHUBTOKEN }}", workflow)
+
     def test_retry_gate_retries_only_mature_docker_hub_429_failures(self):
         module = load_retry_module()
         now = module.parse_timestamp("2026-07-12T06:00:00Z")
@@ -263,17 +283,17 @@ class RenovateAppVersionTests(unittest.TestCase):
 
         self.assertIn("RENOVATE_REPOSITORIES: ${{ github.repository }}", workflow)
 
-    def test_full_renovate_scan_is_scheduled_or_manual_only(self):
+    def test_compose_audit_is_semimonthly_or_manual_only(self):
         workflow = (REPO_ROOT / ".github" / "workflows" / "renovate.yml").read_text(encoding="utf-8")
 
         self.assertNotIn("  push:\n", workflow)
-        self.assertIn('    - cron: "0 0 * * *"', workflow)
+        self.assertIn('    - cron: "23 3 1,15 * *"', workflow)
         self.assertIn("  workflow_dispatch:", workflow)
 
-    def test_full_renovate_scan_does_not_overlap(self):
+    def test_compose_audit_does_not_overlap(self):
         workflow = (REPO_ROOT / ".github" / "workflows" / "renovate.yml").read_text(encoding="utf-8")
 
-        self.assertIn("concurrency:\n  group: renovate-full-scan\n  cancel-in-progress: true", workflow)
+        self.assertIn("concurrency:\n  group: renovate-compose-audit\n  cancel-in-progress: true", workflow)
         self.assertIn("permissions:\n  contents: read", workflow)
         self.assertIn("timeout-minutes: 90", workflow)
 
@@ -371,13 +391,13 @@ class RenovateAppVersionTests(unittest.TestCase):
         self.assertNotIn("pull_request:\n", workflow)
         self.assertNotIn("pull_request_target:\n", workflow)
 
-    def test_hosted_and_self_hosted_renovate_have_disjoint_manager_scopes(self):
+    def test_hosted_renovate_owns_updates_while_self_hosted_is_compose_only(self):
         hosted = json.loads((REPO_ROOT / "renovate.json").read_text(encoding="utf-8"))
         docker = json.loads(
             (REPO_ROOT / ".github" / "renovate-docker.json").read_text(encoding="utf-8")
         )
 
-        self.assertEqual(["github-actions"], hosted["enabledManagers"])
+        self.assertEqual(["github-actions", "docker-compose"], hosted["enabledManagers"])
         self.assertEqual(["docker-compose"], docker["enabledManagers"])
         self.assertTrue(
             (REPO_ROOT / ".github" / "renovate-controller-policy.md").is_file()

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,16 +1,16 @@
-name: Renovate
+name: Renovate Compose audit
 
 on:
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "23 3 1,15 * *"
   workflow_dispatch:
     inputs:
       manual-trigger:
-        description: 'Manually trigger Renovate'
+        description: 'Manually trigger the read-only Compose audit'
         default: ''
 
 concurrency:
-  group: renovate-full-scan
+  group: renovate-compose-audit
   cancel-in-progress: true
 
 permissions:
@@ -47,12 +47,13 @@ jobs:
           configurationFile: .github/renovate-global.js
           docker-cmd-file: .github/scripts/renovate-entrypoint.sh
           docker-volumes: ${{ github.workspace }}/.github/renovate-docker.json:/github-action/renovate-docker.json:ro;/tmp:/tmp
-          token: ${{ secrets.GITHUBTOKEN }}
+          token: ${{ github.token }}
         env:
           RENOVATE_DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
           RENOVATE_DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           RENOVATE_CACHE_DIR: /tmp/renovate-cache
           RENOVATE_CACHE_PRIVATE_PACKAGES: 'false'
+          RENOVATE_DRY_RUN: lookup
           RENOVATE_REPOSITORIES: ${{ github.repository }}
           RENOVATE_REPOSITORY_CACHE: enabled
       - name: Report Renovate cache size

--- a/renovate.json
+++ b/renovate.json
@@ -1,10 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    "github>okxlin/appstore//.github/renovate-docker.json"
   ],
   "enabledManagers": [
-    "github-actions"
+    "github-actions",
+    "docker-compose"
   ],
   "dependencyDashboardTitle": "Dependency Dashboard",
   "rebaseWhen": "never"


### PR DESCRIPTION
## Summary

- let Mend Renovate discover both GitHub Actions and Docker Compose updates
- reuse the existing Compose policy as a repository preset instead of duplicating rules
- convert the self-hosted controller into a read-only lookup audit on the 1st and 15th
- keep the cached Docker Hub audit and bounded 429 retry without allowing self-hosted writes

## Safety

- Mend is the only controller that can create Compose branches and PRs
- the self-hosted audit uses the read-only workflow token and `RENOVATE_DRY_RUN=lookup`
- existing sidecar, version-directory, and automerge guards continue to recognize Mend `renovate/*` branches

## Verification

- 31 Python regression tests
- all JSON and workflow YAML parsed successfully
- changed workflows pass `actionlint`
- Renovate 43 config validator accepted both Renovate JSON files
- `git diff --check`
