### PR TITLE
Use official WuKongIM image sources

### DIFF
--- a/.github/scripts/test_renovate_app_version.py
+++ b/.github/scripts/test_renovate_app_version.py
@@ -278,6 +278,15 @@ class RenovateAppVersionTests(unittest.TestCase):
             )
         )
 
+    def test_wukongim_uses_queryable_official_images(self):
+        compose_text = (
+            REPO_ROOT / "apps" / "wukongim" / "2.0.5" / "docker-compose.yml"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("wukongim/wukongim:v2.0.5-20240925", compose_text)
+        self.assertIn("prom/prometheus:v2.53.1", compose_text)
+        self.assertNotIn("registry.cn-shanghai.aliyuncs.com/wukongim/", compose_text)
+
     def test_self_hosted_renovate_targets_this_repository(self):
         workflow = (REPO_ROOT / ".github" / "workflows" / "renovate.yml").read_text(encoding="utf-8")
 

--- a/apps/wukongim/2.0.5/docker-compose.yml
+++ b/apps/wukongim/2.0.5/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   wukongim: # WuKongIM服务
     container_name: ${CONTAINER_NAME}-wukongim
-    image: "registry.cn-shanghai.aliyuncs.com/wukongim/wukongim:v2.0.5-20240925"
+    image: "wukongim/wukongim:v2.0.5-20240925"
     environment:
       - "WK_CLUSTER_NODEID=1001"
       - "WK_CLUSTER_SERVERADDR=${EXTERNAL_IP}:${PANEL_APP_PORT_COMM}" # 节点内部通信请求地址
@@ -29,7 +29,7 @@ services:
       createdBy: "Apps"
   wukongim-prometheus:  # 监控服务
     container_name: ${CONTAINER_NAME}-prometheus
-    image: "registry.cn-shanghai.aliyuncs.com/wukongim/prometheus:v2.53.1"
+    image: "prom/prometheus:v2.53.1"
     volumes:
       - "./prometheus.yml:/etc/prometheus/prometheus.yml"
     ports:


### PR DESCRIPTION
## Summary

- replace the Aliyun WuKongIM image with the queryable official Docker Hub image
- replace the mirrored Prometheus image with the official multi-architecture image
- add a regression check preventing this version from returning to the unqueryable mirror namespace

## Evidence

- `wukongim/wukongim:v2.0.5-20240925` has the same manifest digest as the current Aliyun image: `sha256:840bc447...`
- the Aliyun Prometheus manifest digest `sha256:e815f1c1...` is the linux/amd64 manifest in `prom/prometheus:v2.53.1`
- no application behavior, tag, environment variable, volume, or port mapping changes

## Verification

- 32 Renovate regression tests
- `docker compose config --no-interpolate`
- adapter variable closure and Compose render checks
- `git diff --check`
