### PR TITLE
Tighten Renovate multi-service safeguards

### DIFF
--- a/.github/renovate-automerge-whitelist.txt
+++ b/.github/renovate-automerge-whitelist.txt
@@ -9,7 +9,6 @@
 upsnap
 code-server
 zeroclaw
-next-terminal
 dpanel
 wallos
 chatgpt-on-wechat
@@ -72,7 +71,6 @@ jellyfin
 vocechat
 lucky
 bitwarden
-woodpecker
 onlyoffice
 tailscale
 nezha-dashboard
@@ -253,13 +251,11 @@ apprise-api-linuxserver
 babybuddy-linuxserver
 bazarr-linuxserver
 beets-linuxserver
-bookstack-linuxserver
 budge-linuxserver
 changedetection.io-linuxserver
 cops-linuxserver
 davos-linuxserver
 ddclient-linuxserver
-diskover-linuxserver
 dokuwiki-linuxserver
 doplarr-linuxserver
 duckdns-linuxserver
@@ -272,14 +268,12 @@ freshrss-linuxserver
 grav-linuxserver
 grocy-linuxserver
 habridge-linuxserver
-hedgedoc-linuxserver
 hishtory-server-linuxserver
 homeassistant-linuxserver
 htpcmanager-linuxserver
 jackett-linuxserver
 jellyfin-linuxserver
 kavita-linuxserver
-kimai-linuxserver
 lazylibrarian-linuxserver
 ldap-auth-linuxserver
 librespeed-linuxserver
@@ -288,7 +282,6 @@ luanti-linuxserver
 lychee-linuxserver
 medusa-linuxserver
 modmanager-linuxserver
-monica-linuxserver
 mstream-linuxserver
 mylar3-linuxserver
 nginx-linuxserver
@@ -303,7 +296,6 @@ overseerr-linuxserver
 pairdrop-linuxserver
 phpmyadmin-linuxserver
 piwigo-linuxserver
-planka-linuxserver
 projectsend-linuxserver
 prowlarr-linuxserver
 pwndrop-linuxserver
@@ -322,7 +314,6 @@ tautulli-linuxserver
 thelounge-linuxserver
 tvheadend-linuxserver
 ubooquity-linuxserver
-unifi-network-application-linuxserver
 webgrabplus-linuxserver
 wikijs-linuxserver
 xbackbone-linuxserver

--- a/.github/renovate-docker.json
+++ b/.github/renovate-docker.json
@@ -569,6 +569,16 @@
       "enabled": false
     },
     {
+      "description": "Disable sidecar-only Prometheus updates for the fixed WuKongIM 2.0.5 stack",
+      "matchFileNames": [
+        "apps/wukongim/2.0.5/docker-compose.yml"
+      ],
+      "matchPackageNames": [
+        "prom/prometheus"
+      ],
+      "enabled": false
+    },
+    {
       "description": "Require dashboard approval for major updates of stateful Docker sidecars",
       "matchDatasources": [
         "docker"

--- a/.github/renovate-primary-services.json
+++ b/.github/renovate-primary-services.json
@@ -31,5 +31,8 @@
   ],
   "teldrive": [
     "teldrive"
+  ],
+  "wukongim": [
+    "wukongim"
   ]
 }

--- a/.github/scripts/test_renovate_app_version.py
+++ b/.github/scripts/test_renovate_app_version.py
@@ -306,6 +306,43 @@ class RenovateAppVersionTests(unittest.TestCase):
         self.assertIn("prom/prometheus:v2.53.1", compose_text)
         self.assertNotIn("registry.cn-shanghai.aliyuncs.com/wukongim/", compose_text)
 
+    def test_wukongim_primary_service_and_sidecar_policy_are_explicit(self):
+        primary = json.loads(
+            (REPO_ROOT / ".github" / "renovate-primary-services.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        config = json.loads(DOCKER_CONFIG.read_text(encoding="utf-8"))
+
+        self.assertEqual(["wukongim"], primary["wukongim"])
+        self.assertTrue(
+            any(
+                rule.get("enabled") is False
+                and "apps/wukongim/2.0.5/docker-compose.yml"
+                in rule.get("matchFileNames", [])
+                and "prom/prometheus" in rule.get("matchPackageNames", [])
+                for rule in config["packageRules"]
+            )
+        )
+
+    def test_automerge_whitelist_contains_only_single_service_apps(self):
+        apps = [
+            line.strip()
+            for line in (
+                REPO_ROOT / ".github" / "renovate-automerge-whitelist.txt"
+            ).read_text(encoding="utf-8").splitlines()
+            if line.strip() and not line.lstrip().startswith("#")
+        ]
+        multi_service = []
+        for app in apps:
+            for compose_path in (REPO_ROOT / "apps" / app).glob("*/docker-compose.yml"):
+                compose_data = yaml.safe_load(compose_path.read_text(encoding="utf-8")) or {}
+                services = compose_data.get("services") or {}
+                if len(services) != 1:
+                    multi_service.append(f"{app}:{compose_path.parent.name}:{len(services)}")
+
+        self.assertEqual([], multi_service)
+
     def test_self_hosted_renovate_targets_this_repository(self):
         workflow = (REPO_ROOT / ".github" / "workflows" / "renovate.yml").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary

- model WuKongIM's primary service explicitly
- suppress Prometheus-only Renovate updates for the fixed WuKongIM 2.0.5 stack
- remove nine multi-service apps from the single-service automerge whitelist
- add regression coverage requiring every whitelisted app version to contain exactly one service

## Why

Mend created #4766 and #4767 for the WuKongIM Prometheus sidecar only. The sidecar guard allowed them because WuKongIM had no primary-service mapping. The automerge workflow remained safe because it independently requires exactly one service, but the policy mismatch left noisy PRs open and caused invalid automerge attempts for other multi-service whitelist entries.

## Verification

- 35 regression tests
- whitelist audit: 355 entries, zero missing directories, zero multi-service apps
- all JSON and workflow YAML parsed successfully
- all workflows pass `actionlint`
- `git diff --check`
