### PR TITLE
Fix third-party PR label workflow

### DIFF
--- a/.github/scripts/test_label_third_party_workflow.py
+++ b/.github/scripts/test_label_third_party_workflow.py
@@ -39,8 +39,10 @@ class LabelThirdPartyWorkflowTests(unittest.TestCase):
             step["env"],
         )
         self.assertIn("gh api --method POST", step["run"])
+        self.assertIn("--silent", step["run"])
         self.assertIn('repos/${GH_REPO}/issues/${PR_NUMBER}/labels', step["run"])
         self.assertIn("labels[]=pending", step["run"])
+        self.assertIn("echo 'labels: pending'", step["run"])
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_label_third_party_workflow.py
+++ b/.github/scripts/test_label_third_party_workflow.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+import unittest
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "label-third-party-prs.yml"
+
+
+class LabelThirdPartyWorkflowTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.workflow_text = WORKFLOW_PATH.read_text(encoding="utf-8")
+        cls.workflow = yaml.load(cls.workflow_text, Loader=yaml.BaseLoader)
+
+    def test_keeps_the_existing_event_scope_and_minimal_permission(self) -> None:
+        self.assertEqual(
+            ["opened", "reopened"],
+            self.workflow["on"]["pull_request_target"]["types"],
+        )
+        self.assertEqual({"pull-requests": "write"}, self.workflow["permissions"])
+
+        condition = self.workflow["jobs"]["add-pending-label"]["if"]
+        self.assertIn("app/renovate", condition)
+        self.assertIn("renovate[bot]", condition)
+        self.assertIn("selfhosted-renovate/", condition)
+
+    def test_adds_the_pending_label_with_authenticated_github_cli(self) -> None:
+        step = self.workflow["jobs"]["add-pending-label"]["steps"][0]
+        self.assertNotIn("uses", step)
+        self.assertEqual(
+            {
+                "GH_TOKEN": "${{ secrets.GITHUB_TOKEN }}",
+                "GH_REPO": "${{ github.repository }}",
+                "PR_NUMBER": "${{ github.event.pull_request.number }}",
+            },
+            step["env"],
+        )
+        self.assertIn("gh api --method POST", step["run"])
+        self.assertIn('repos/${GH_REPO}/issues/${PR_NUMBER}/labels', step["run"])
+        self.assertIn("labels[]=pending", step["run"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/label-third-party-prs.yml
+++ b/.github/workflows/label-third-party-prs.yml
@@ -24,6 +24,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Add pending label to third-party PRs
-        uses: actions-ecosystem/action-add-labels@v1
-        with:
-          labels: pending
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh api --method POST \
+            "repos/${GH_REPO}/issues/${PR_NUMBER}/labels" \
+            -f 'labels[]=pending'

--- a/.github/workflows/label-third-party-prs.yml
+++ b/.github/workflows/label-third-party-prs.yml
@@ -29,6 +29,7 @@ jobs:
           GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          gh api --method POST \
+          gh api --method POST --silent \
             "repos/${GH_REPO}/issues/${PR_NUMBER}/labels" \
             -f 'labels[]=pending'
+          echo 'labels: pending'


### PR DESCRIPTION
## Summary

- replace the deprecated `actions-ecosystem/action-add-labels@v1` step with the runner-provided authenticated GitHub CLI
- keep the existing `pull_request_target` scope and minimal `pull-requests: write` permission
- emit the stable `labels: pending` marker only after the API request succeeds
- add regression tests for the trigger, permission, trusted inputs, API call, and marker

## Why

The deprecated Node.js action emits a Node 20 deprecation annotation even when the label is added successfully. The maintainer audit correctly treats that annotation as a workflow semantic failure, which blocks otherwise valid app PRs.

This follows GitHub's documented GitHub CLI workflow pattern and the REST endpoint for adding labels:

- https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-github-cli
- https://docs.github.com/en/rest/issues/labels#add-labels-to-an-issue
- https://cli.github.com/manual/gh_api

## Verification

- regression test reproduced the missing stable marker before the final change
- `python3 -m unittest discover -s .github/scripts -p 'test_*.py'` — 37 passed
- `actionlint` — passed
- workflow YAML parse — passed
- `git diff --check` — passed
- merge-tree check against latest `localApps` — clean
