### PR TITLE
Fix version updates after manual directory renames

### DIFF
--- a/.github/scripts/renovate_app_version.py
+++ b/.github/scripts/renovate_app_version.py
@@ -104,6 +104,61 @@ def git_show(ref: str, path: str) -> str:
     return result.stdout
 
 
+def git_rename_source(ref: str, path: str) -> str | None:
+    result = subprocess.run(
+        [
+            "git",
+            "diff",
+            "--find-renames",
+            "--name-status",
+            "-z",
+            "--diff-filter=R",
+            ref,
+            "HEAD",
+        ],
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip()
+        raise RuntimeError(detail or f"unable to compare {ref} with HEAD")
+
+    fields = result.stdout.split("\0")
+    if fields and fields[-1] == "":
+        fields.pop()
+    if len(fields) % 3 != 0:
+        raise RuntimeError("unable to parse renamed paths from git diff")
+
+    matches = [
+        source
+        for status, source, target in zip(fields[0::3], fields[1::3], fields[2::3])
+        if status.startswith("R") and target == path
+    ]
+    if len(matches) > 1:
+        raise RuntimeError(f"multiple rename sources found for {path}")
+    return matches[0] if matches else None
+
+
+def validate_historical_compose_path(app: str, raw_path: str) -> str:
+    path = PurePosixPath(raw_path)
+    expected_app_dir = PurePosixPath("apps") / app
+    if path.name != "docker-compose.yml" or path.parent.parent != expected_app_dir:
+        raise ValueError(f"historical compose path must be inside {expected_app_dir}/<version>")
+    return path.as_posix()
+
+
+def load_base_compose_text(base_ref: str, compose_path: str, app: str) -> str:
+    try:
+        return git_show(base_ref, compose_path)
+    except RuntimeError:
+        rename_source = git_rename_source(base_ref, compose_path)
+        if rename_source is None:
+            raise
+        historical_path = validate_historical_compose_path(app, rename_source)
+        return git_show(base_ref, historical_path)
+
+
 def validate_compose_path(app: str, old_version: str, raw_path: str) -> str:
     path = PurePosixPath(raw_path)
     expected_parent = PurePosixPath("apps") / app / old_version
@@ -123,7 +178,10 @@ def main() -> int:
 
     compose_path = validate_compose_path(args.app, args.old_version, args.compose)
     head_compose = load_yaml_text(Path(compose_path).read_text(encoding="utf-8"), "head compose")
-    base_compose = load_yaml_text(git_show(args.base_ref, compose_path), "base compose")
+    base_compose = load_yaml_text(
+        load_base_compose_text(args.base_ref, compose_path, args.app),
+        "base compose",
+    )
     policy_payload = json.loads(Path(args.policy_file).read_text(encoding="utf-8"))
     if not isinstance(policy_payload, dict):
         raise ValueError("primary service policy must decode to an object")

--- a/.github/scripts/test_renovate_app_version.py
+++ b/.github/scripts/test_renovate_app_version.py
@@ -3,6 +3,7 @@ import json
 import os
 import pathlib
 import subprocess
+import sys
 import tempfile
 import unittest
 
@@ -150,6 +151,160 @@ class RenovateAppVersionTests(unittest.TestCase):
         module = load_module()
 
         self.assertEqual("", module.image_tag("example/demo@sha256:deadbeef"))
+
+    def test_cli_reads_base_compose_from_rename_source(self):
+        with tempfile.TemporaryDirectory(prefix="renovate-version-rename-") as tmp:
+            repo = pathlib.Path(tmp)
+            old_dir = repo / "apps" / "demo" / "1.0.0"
+            new_dir = repo / "apps" / "demo" / "1.0.1"
+            old_dir.mkdir(parents=True)
+            (old_dir / "docker-compose.yml").write_text(
+                yaml.safe_dump(compose({"demo": "example/demo:1.0.1"})),
+                encoding="utf-8",
+            )
+            policy_file = repo / "policy.json"
+            policy_file.write_text("{}\n", encoding="utf-8")
+
+            subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+            subprocess.run(
+                ["git", "config", "user.email", "test@example.com"],
+                cwd=repo,
+                check=True,
+            )
+            subprocess.run(
+                ["git", "config", "user.name", "Test User"],
+                cwd=repo,
+                check=True,
+            )
+            subprocess.run(["git", "add", "apps"], cwd=repo, check=True)
+            subprocess.run(
+                ["git", "commit", "-qm", "add old version"],
+                cwd=repo,
+                check=True,
+            )
+            base_ref = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=repo,
+                check=True,
+                text=True,
+                capture_output=True,
+            ).stdout.strip()
+            subprocess.run(
+                ["git", "mv", str(old_dir.relative_to(repo)), str(new_dir.relative_to(repo))],
+                cwd=repo,
+                check=True,
+            )
+            subprocess.run(
+                ["git", "commit", "-qm", "rename version directory"],
+                cwd=repo,
+                check=True,
+            )
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT_PATH),
+                    "--app",
+                    "demo",
+                    "--old-version",
+                    "1.0.1",
+                    "--compose",
+                    str((new_dir / "docker-compose.yml").relative_to(repo)),
+                    "--base-ref",
+                    base_ref,
+                    "--policy-file",
+                    str(policy_file),
+                ],
+                cwd=repo,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertEqual("", result.stdout)
+        self.assertIn("skip: no service image changed", result.stderr)
+
+    def test_cli_rejects_new_compose_without_base_or_rename(self):
+        with tempfile.TemporaryDirectory(prefix="renovate-version-new-compose-") as tmp:
+            repo = pathlib.Path(tmp)
+            policy_file = repo / "policy.json"
+            policy_file.write_text("{}\n", encoding="utf-8")
+
+            subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+            subprocess.run(
+                ["git", "config", "user.email", "test@example.com"],
+                cwd=repo,
+                check=True,
+            )
+            subprocess.run(
+                ["git", "config", "user.name", "Test User"],
+                cwd=repo,
+                check=True,
+            )
+            subprocess.run(
+                ["git", "commit", "--allow-empty", "-qm", "empty base"],
+                cwd=repo,
+                check=True,
+            )
+            base_ref = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=repo,
+                check=True,
+                text=True,
+                capture_output=True,
+            ).stdout.strip()
+
+            compose_path = repo / "apps" / "demo" / "1.0.1" / "docker-compose.yml"
+            compose_path.parent.mkdir(parents=True)
+            compose_path.write_text(
+                yaml.safe_dump(compose({"demo": "example/demo:1.0.1"})),
+                encoding="utf-8",
+            )
+            subprocess.run(["git", "add", "apps"], cwd=repo, check=True)
+            subprocess.run(
+                ["git", "commit", "-qm", "add new compose"],
+                cwd=repo,
+                check=True,
+            )
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT_PATH),
+                    "--app",
+                    "demo",
+                    "--old-version",
+                    "1.0.1",
+                    "--compose",
+                    str(compose_path.relative_to(repo)),
+                    "--base-ref",
+                    base_ref,
+                    "--policy-file",
+                    str(policy_file),
+                ],
+                cwd=repo,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn("apps/demo/1.0.1/docker-compose.yml", result.stderr)
+
+    def test_historical_compose_path_must_stay_in_the_same_app(self):
+        module = load_module()
+
+        self.assertEqual(
+            "apps/demo/1.0.0/docker-compose.yml",
+            module.validate_historical_compose_path(
+                "demo", "apps/demo/1.0.0/docker-compose.yml"
+            ),
+        )
+        with self.assertRaisesRegex(ValueError, "must be inside apps/demo"):
+            module.validate_historical_compose_path(
+                "demo", "apps/other/1.0.0/docker-compose.yml"
+            )
 
     def test_single_service_uses_the_changed_service_tag(self):
         module = load_module()


### PR DESCRIPTION
## Summary

- resolve a compose file's historical path from Git rename metadata when maintainers already renamed the version directory
- restrict fallback paths to the same app and keep unmatched new files as hard failures
- add real temporary-Git regression coverage for rename and missing-base cases

## Verification

- `python3 -m unittest discover -s .github/scripts -p "test_*.py"` (40 tests)
- replayed the Matomo `8994d27ab -> ac2d973b9` failure scenario through the selector and workflow wrapper
- `python3 -m py_compile .github/scripts/renovate_app_version.py .github/scripts/test_renovate_app_version.py`
- `git diff --check`