### PR TITLE
Suppress DooTask sidecar-only Renovate updates

### DIFF
--- a/.github/renovate-docker.json
+++ b/.github/renovate-docker.json
@@ -526,6 +526,16 @@
       "enabled": false
     },
     {
+      "description": "Disable sidecar-only Renovate updates for DooTask multi-service tracks",
+      "matchFileNames": [
+        "apps/dootask/**/docker-compose.yml"
+      ],
+      "matchPackageNames": [
+        "nginx"
+      ],
+      "enabled": false
+    },
+    {
       "description": "Disable sidecar-only Renovate updates for Diskover multi-service tracks",
       "matchFileNames": [
         "apps/diskover-linuxserver/**/docker-compose.yml"

--- a/.github/renovate-primary-services.json
+++ b/.github/renovate-primary-services.json
@@ -3,6 +3,9 @@
     "clearflask-connect",
     "clearflask-server"
   ],
+  "dootask": [
+    "dootask"
+  ],
   "dify": [
     "api",
     "api_websocket",


### PR DESCRIPTION
## Summary

- register `dootask` as the primary service for the multi-service app guard
- disable standalone Renovate updates for the auxiliary `nginx` image
- prevent future sidecar-only PRs when the main DooTask image is unchanged

## Verification

- JSON validation for Renovate policy files
- `renovate_whitelist_audit.py --only-problems`
- sidecar guard replay for closed PR #4891 returns `close` for both fixed and latest Compose files
- no application image or runtime package changes