### PR TITLE
Expand Renovate automerge whitelist

### DIFF
--- a/.github/renovate-automerge-whitelist.txt
+++ b/.github/renovate-automerge-whitelist.txt
@@ -238,6 +238,10 @@ webos
 wewe-rss
 windows
 wireguard
+blender-linuxserver
+forwardx
+weaviate
+infinite-canvas
 wol-go-web
 xunlei
 yesplaymusic


### PR DESCRIPTION
## Changes

Add four stable single-service apps to the Renovate automerge whitelist:

- `blender-linuxserver`
- `forwardx`
- `weaviate`
- `infinite-canvas`

## Maintenance evidence

- Blender upgraded from `5.1.2` to `5.2.0` in 1Panel v2; install, HTTP access, restart, uninstall, and cleanup passed.
- ForwardX upgraded from `2.3.237` to `2.3.238` with the same checks passing.
- Weaviate upgraded from `1.38.4` to `1.38.5` with the same checks passing.
- Infinite Canvas `latest` and `0.8.2` both passed fresh-install, HTTP, restart, uninstall, and cleanup checks.
- All four are single-service, have stable compose shape, and have no privileged, host-network, GPU, or device bindings.

## Verification

- `python3 .github/scripts/renovate_whitelist_audit.py --apps-file .github/renovate-automerge-whitelist.txt --only-problems`
- `python3 .github/scripts/test_renovate_app_version.py` (39 tests passed)
