### PR TITLE
Allow OpenObserve Renovate automerge

### DIFF
--- a/.github/renovate-automerge-whitelist.txt
+++ b/.github/renovate-automerge-whitelist.txt
@@ -242,6 +242,7 @@ blender-linuxserver
 forwardx
 weaviate
 infinite-canvas
+openobserve
 wol-go-web
 xunlei
 yesplaymusic


### PR DESCRIPTION
## Change

Add `openobserve` to the Renovate automerge whitelist.

## Maintenance evidence

- The current update is image-only and keeps the single-service compose shape unchanged.
- A real 1Panel v2 upgrade from `0.91.1` to `0.91.2` passed installation, health, HTTP redirect handling, restart, uninstall, and backend cleanup.
- The app has no privileged, host-network, GPU, device, or sidecar requirements.
- The whitelist audit reports `eligible=true`, `compose_stable=true`, and `max_services=1`.

## Verification

- `python3 .github/scripts/renovate_whitelist_audit.py --app openobserve`
- `python3 .github/scripts/renovate_whitelist_audit.py --apps-file .github/renovate-automerge-whitelist.txt --only-problems`
- `python3 .github/scripts/test_renovate_app_version.py` (39 tests passed)
