### PR TITLE
ci: whitelist stable single-service Renovate apps

### DIFF
--- a/.github/renovate-automerge-whitelist.txt
+++ b/.github/renovate-automerge-whitelist.txt
@@ -369,3 +369,10 @@ signal-linuxserver
 thunderbird-linuxserver
 ting-reader
 vscode-linuxserver
+
+# Reviewed single-service Renovate candidates (2026-07-19).
+cpa-manager-plus
+ech0
+flipt
+helium-linuxserver
+wakapi


### PR DESCRIPTION
## Scope

Add five reviewed single-service applications to the Renovate automerge whitelist:

- `cpa-manager-plus`
- `ech0`
- `flipt`
- `helium-linuxserver`
- `wakapi`

## Evidence

- Current and latest compose snapshots are single-service and structurally stable.
- No privileged, host-network, Docker Socket, device, or other special runtime flags.
- Recent image-only Renovate updates passed real old-to-new 1Panel v2 upgrade smoke.
- Ech0 `5.4.4 -> 5.4.6` was revalidated in this maintenance pass.
- `renovate_whitelist_audit.py` reports `eligible=true` for all five candidates.
- Existing multi-service and special-permission apps remain outside this change.

The repository workflow still enforces app scope, single compose, single service, and image-only changes before automerge.