### PR TITLE
fix(apps): harden OCI Mirror initialization

### DIFF
--- a/apps/oci-mirror/0.1.2/.env.sample
+++ b/apps/oci-mirror/0.1.2/.env.sample
@@ -2,11 +2,13 @@ CONTAINER_NAME=oci-mirror
 OCI_MIRROR_ROLE=gateway
 OCI_MIRROR_TRANSPORT_MODE=mtls
 PANEL_APP_PORT_HTTP=8443
+OCI_MIRROR_GATEWAY_LISTEN_IP=0.0.0.0
 OCI_MIRROR_GATEWAY_MANAGEMENT_IP=127.0.0.1
 PANEL_APP_PORT_MANAGEMENT=19090
 OCI_MIRROR_PUBLIC_HOST=mirror.example.com
 OCI_MIRROR_IP_ALLOWLIST=
 OCI_MIRROR_CHINA_CIDR_FILE=
+OCI_MIRROR_CHINA_CIDR_REFRESH_DAYS=30
 # Optional provenance overrides for a custom CIDR file.
 # 1Panel derives these for the automatically generated APNIC dataset.
 OCI_MIRROR_CHINA_CIDR_SOURCE=https://ftp.apnic.net/stats/apnic/delegated-apnic-latest
@@ -17,10 +19,13 @@ OCI_MIRROR_DATA_DIR=./data
 OCI_MIRROR_PKI_DIR=./pki
 OCI_MIRROR_MTLS_GATEWAY_ID=gateway-1
 OCI_MIRROR_MTLS_EGRESS_CERTS=egress-a=egress.example.com
+# Renew generated leaf certificates when fewer than this many valid days remain.
+OCI_MIRROR_MTLS_RENEW_BEFORE_DAYS=30
+# Required only for the Gateway role.
 OCI_MIRROR_MANAGEMENT_TOKEN=
 OCI_MIRROR_EGRESS_NODE_ID=egress-a
 OCI_MIRROR_EGRESS_PROXY_URL=https://egress.example.com:8443
-# Comma-separated concrete public IPv4/IPv6 addresses assigned or routed to Egress; no CIDR, maximum 256.
+# Required only for the Gateway role: comma-separated concrete public IPv4/IPv6 addresses assigned or routed to Egress; no CIDR, maximum 256.
 # IPv6 rotation entries must come from distinct /64 networks.
 OCI_MIRROR_EGRESS_SOURCE_ADDRESSES=
 OCI_MIRROR_EGRESS_LISTEN_IP=0.0.0.0

--- a/apps/oci-mirror/0.1.2/data.yml
+++ b/apps/oci-mirror/0.1.2/data.yml
@@ -59,6 +59,22 @@ additionalProperties:
       required: true
       rule: paramPort
       type: number
+    - default: 0.0.0.0
+      edit: true
+      envKey: OCI_MIRROR_GATEWAY_LISTEN_IP
+      labelEn: Gateway Public Listen IP
+      labelZh: Gateway 公网监听 IP
+      label:
+        en: Gateway Public Listen IP
+        zh: Gateway 公网监听 IP
+        zh-Hant: Gateway 公網監聽 IP
+        ja: Gateway 公開リッスン IP
+        ko: Gateway 공용 수신 IP
+        ru: Публичный IP прослушивания Gateway
+        ms: IP Dengar Awam Gateway
+        pt-br: IP de Escuta Público do Gateway
+      required: false
+      type: text
     - default: 127.0.0.1
       edit: true
       envKey: OCI_MIRROR_GATEWAY_MANAGEMENT_IP
@@ -111,17 +127,26 @@ additionalProperties:
     - default: ""
       edit: true
       envKey: OCI_MIRROR_IP_ALLOWLIST
-      labelEn: Additional Allowed Client IP/CIDR
-      labelZh: 额外允许的客户端 IP/CIDR
+      labelEn: Additional Allowed Client IPs/CIDRs
+      labelZh: 额外允许的客户端 IP/CIDR 列表
       label:
-        en: Additional Allowed Client IP/CIDR
-        zh: 额外允许的客户端 IP/CIDR
-        zh-Hant: 額外允許的用戶端 IP/CIDR
-        ja: 追加許可クライアント IP/CIDR
-        ko: 추가 허용 클라이언트 IP/CIDR
-        ru: Дополнительный разрешенный IP/CIDR
-        ms: IP/CIDR Klien Tambahan
-        pt-br: IP/CIDR Adicional Permitido
+        en: Additional Allowed Client IPs/CIDRs
+        zh: 额外允许的客户端 IP/CIDR 列表
+        zh-Hant: 額外允許的用戶端 IP/CIDR 清單
+        ja: 追加許可クライアント IP/CIDR リスト
+        ko: 추가 허용 클라이언트 IP/CIDR 목록
+        ru: Дополнительные разрешенные IP/CIDR
+        ms: Senarai IP/CIDR Klien Tambahan
+        pt-br: IPs/CIDRs Adicionais Permitidos
+      description:
+        en: Optional comma-separated IPv4/IPv6 addresses or CIDR prefixes.
+        zh: 可选，多个 IPv4/IPv6 地址或 CIDR 网段使用英文逗号分隔。
+        zh-Hant: 可選，多個 IPv4/IPv6 位址或 CIDR 網段以英文逗號分隔。
+        ja: 任意。複数の IPv4/IPv6 アドレスまたは CIDR をカンマで区切ります。
+        ko: 선택 사항이며 여러 IPv4/IPv6 주소 또는 CIDR을 쉼표로 구분합니다.
+        ru: Необязательно; IPv4/IPv6-адреса и CIDR указываются через запятую.
+        ms: Pilihan; pisahkan alamat IPv4/IPv6 atau CIDR dengan koma.
+        pt-br: Opcional; separe endereços IPv4/IPv6 ou CIDRs por vírgulas.
       required: false
       type: text
     - default: ""
@@ -140,6 +165,22 @@ additionalProperties:
         pt-br: 'Arquivo CIDR da China Continental (Opcional, vazio para gerar automaticamente)'
       required: false
       type: text
+    - default: 30
+      edit: true
+      envKey: OCI_MIRROR_CHINA_CIDR_REFRESH_DAYS
+      labelEn: Managed CIDR Refresh Interval (Days)
+      labelZh: 托管 CIDR 刷新间隔（天）
+      label:
+        en: Managed CIDR Refresh Interval (Days)
+        zh: 托管 CIDR 刷新间隔（天）
+        zh-Hant: 代管 CIDR 重新整理間隔（天）
+        ja: 管理 CIDR 更新間隔（日）
+        ko: 관리형 CIDR 새로 고침 간격(일)
+        ru: Интервал обновления управляемого CIDR (дни)
+        ms: Selang Muat Semula CIDR Terurus (Hari)
+        pt-br: Intervalo de Atualização do CIDR Gerenciado (Dias)
+      required: false
+      type: number
     - default: "true"
       edit: true
       envKey: OCI_MIRROR_TLS_ENABLED
@@ -256,15 +297,15 @@ additionalProperties:
         ms: Token Pengurusan Gateway
         pt-br: Token de Gerenciamento do Gateway
       description:
-        en: Use 32-4096 bytes containing only A-Z, a-z, 0-9, . _ ~ + / -, with optional = padding only at the end. It must differ from every Egress token.
-        zh: 使用 32-4096 字节，仅允许 A-Z、a-z、0-9、. _ ~ + / -，= 只能作为末尾填充。必须与所有 Egress Token 不同。
-        zh-Hant: 使用 32-4096 位元組，僅允許 A-Z、a-z、0-9、. _ ~ + / -，= 只能作為末尾填充。必須與所有 Egress Token 不同。
-        ja: 32～4096 バイトで、A-Z、a-z、0-9、. _ ~ + / - のみ使用できます。= は末尾のパディングにのみ使用でき、すべての Egress Token と異なる値が必要です。
-        ko: 32-4096바이트이며 A-Z, a-z, 0-9, . _ ~ + / -만 사용할 수 있습니다. =는 끝 패딩에만 사용할 수 있고 모든 Egress Token과 달라야 합니다.
-        ru: Длина 32-4096 байт; допустимы A-Z, a-z, 0-9, . _ ~ + / -, а = только в конце. Значение должно отличаться от всех токенов Egress.
-        ms: Gunakan 32-4096 bait yang hanya mengandungi A-Z, a-z, 0-9, . _ ~ + / -, dengan = hanya sebagai pelapik di hujung. Nilai mesti berbeza daripada semua token Egress.
-        pt-br: Use 32-4096 bytes contendo apenas A-Z, a-z, 0-9, . _ ~ + / -, com = somente como preenchimento no final. O valor deve ser diferente de todos os tokens Egress.
-      required: true
+        en: Required only for Gateway. Use 32-4096 bytes containing only A-Z, a-z, 0-9, . _ ~ + / -, with optional = padding only at the end. It must differ from every Egress token.
+        zh: 仅 Gateway 必填。使用 32-4096 字节，仅允许 A-Z、a-z、0-9、. _ ~ + / -，= 只能作为末尾填充。必须与所有 Egress Token 不同。
+        zh-Hant: 僅 Gateway 必填。使用 32-4096 位元組，僅允許 A-Z、a-z、0-9、. _ ~ + / -，= 只能作為末尾填充。必須與所有 Egress Token 不同。
+        ja: Gateway のみ必須です。32～4096 バイトで、A-Z、a-z、0-9、. _ ~ + / - のみ使用できます。= は末尾のパディングにのみ使用でき、すべての Egress Token と異なる値が必要です。
+        ko: Gateway에서만 필수입니다. 32-4096바이트이며 A-Z, a-z, 0-9, . _ ~ + / -만 사용할 수 있습니다. =는 끝 패딩에만 사용할 수 있고 모든 Egress Token과 달라야 합니다.
+        ru: Обязательно только для Gateway. Длина 32-4096 байт; допустимы A-Z, a-z, 0-9, . _ ~ + / -, а = только в конце. Значение должно отличаться от всех токенов Egress.
+        ms: Wajib untuk Gateway sahaja. Gunakan 32-4096 bait yang hanya mengandungi A-Z, a-z, 0-9, . _ ~ + / -, dengan = hanya sebagai pelapik di hujung. Nilai mesti berbeza daripada semua token Egress.
+        pt-br: Obrigatório somente para Gateway. Use 32-4096 bytes contendo apenas A-Z, a-z, 0-9, . _ ~ + / -, com = somente como preenchimento no final. O valor deve ser diferente de todos os tokens Egress.
+      required: false
       type: password
     - default: egress-a
       edit: true
@@ -313,15 +354,15 @@ additionalProperties:
         ms: Alamat Sumber Awam Egress
         pt-br: Endereços Públicos de Origem do Egress
       description:
-        en: Comma-separated concrete IPv4/IPv6 addresses assigned or routed to the Egress host; CIDR prefixes are not accepted. Up to 256 addresses are supported, and IPv6 rotation addresses must use distinct /64 networks.
-        zh: 填写已分配或路由到 Egress 主机的具体 IPv4/IPv6 地址，多个用逗号分隔，不接受 CIDR 前缀。最多 256 个，IPv6 轮换地址必须来自不同的 /64。
-        zh-Hant: 填寫已分配或路由到 Egress 主機的具體 IPv4/IPv6 位址，多個以逗號分隔，不接受 CIDR 前綴。最多 256 個，IPv6 輪換位址必須來自不同的 /64。
-        ja: Egress ホストに割り当てまたはルーティングされた具体的な IPv4/IPv6 アドレスをカンマ区切りで入力します。CIDR プレフィックスは使用できません。最大 256 個で、IPv6 ローテーション用アドレスは異なる /64 を使用する必要があります。
-        ko: Egress 호스트에 할당되었거나 라우팅된 구체적인 IPv4/IPv6 주소를 쉼표로 구분해 입력하세요. CIDR 접두사는 허용되지 않습니다. 최대 256개며 IPv6 순환 주소는 서로 다른 /64를 사용해야 합니다.
-        ru: Укажите через запятую конкретные IPv4/IPv6-адреса, назначенные или маршрутизируемые на узел Egress; CIDR-префиксы недопустимы. До 256 адресов; IPv6-адреса для ротации должны быть из разных /64.
-        ms: Masukkan alamat IPv4/IPv6 khusus yang diperuntukkan atau dihalakan ke hos Egress, dipisahkan dengan koma; awalan CIDR tidak diterima. Sehingga 256 alamat disokong dan alamat putaran IPv6 mesti menggunakan rangkaian /64 yang berbeza.
-        pt-br: Informe endereços IPv4/IPv6 concretos atribuídos ou roteados ao host Egress, separados por vírgulas; prefixos CIDR não são aceitos. São suportados até 256 endereços, e os endereços IPv6 de rotação devem usar redes /64 distintas.
-      required: true
+        en: Required only for Gateway. Enter comma-separated concrete public IPv4/IPv6 addresses assigned or routed to the Egress host; CIDR prefixes are not accepted. Up to 256 addresses are supported, and IPv6 rotation addresses must use distinct /64 networks.
+        zh: 仅 Gateway 必填。填写已分配或路由到 Egress 主机的具体公网 IPv4/IPv6 地址，多个用英文逗号分隔，不接受 CIDR 前缀。最多 256 个，IPv6 轮换地址必须来自不同的 /64。
+        zh-Hant: 僅 Gateway 必填。填寫已分配或路由到 Egress 主機的具體公網 IPv4/IPv6 位址，多個以英文逗號分隔，不接受 CIDR 前綴。最多 256 個，IPv6 輪換位址必須來自不同的 /64。
+        ja: Gateway のみ必須です。Egress ホストに割り当てまたはルーティングされた具体的な公開 IPv4/IPv6 アドレスをカンマ区切りで入力します。CIDR プレフィックスは使用できません。最大 256 個で、IPv6 ローテーション用アドレスは異なる /64 を使用する必要があります。
+        ko: Gateway에서만 필수입니다. Egress 호스트에 할당되었거나 라우팅된 구체적인 공인 IPv4/IPv6 주소를 쉼표로 구분해 입력하세요. CIDR 접두사는 허용되지 않습니다. 최대 256개며 IPv6 순환 주소는 서로 다른 /64를 사용해야 합니다.
+        ru: Обязательно только для Gateway. Укажите через запятую конкретные публичные IPv4/IPv6-адреса, назначенные или маршрутизируемые на узел Egress; CIDR-префиксы недопустимы. До 256 адресов; IPv6-адреса для ротации должны быть из разных /64.
+        ms: Wajib untuk Gateway sahaja. Masukkan alamat IPv4/IPv6 awam khusus yang diperuntukkan atau dihalakan ke hos Egress, dipisahkan dengan koma; awalan CIDR tidak diterima. Sehingga 256 alamat disokong dan alamat putaran IPv6 mesti menggunakan rangkaian /64 yang berbeza.
+        pt-br: Obrigatório somente para Gateway. Informe endereços IPv4/IPv6 públicos concretos atribuídos ou roteados ao host Egress, separados por vírgulas; prefixos CIDR não são aceitos. São suportados até 256 endereços, e os endereços IPv6 de rotação devem usar redes /64 distintas.
+      required: false
       type: text
     - default: 0.0.0.0
       edit: true

--- a/apps/oci-mirror/0.1.2/docker-compose.yml
+++ b/apps/oci-mirror/0.1.2/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       - /etc/oci-mirror/runtime.json
     environment:
       - TZ=${TIME_ZONE}
-      - OCI_MIRROR_MANAGEMENT_TOKEN=${OCI_MIRROR_MANAGEMENT_TOKEN}
+      - OCI_MIRROR_MANAGEMENT_TOKEN=${OCI_MIRROR_MANAGEMENT_TOKEN:-}
       - OCI_MIRROR_EGRESS_TOKEN=${OCI_MIRROR_EGRESS_TOKEN}
       - SSL_CERT_FILE=/etc/oci-mirror/pki/trust-bundle.crt
     volumes:

--- a/apps/oci-mirror/0.1.2/scripts/bootstrap-pki.sh
+++ b/apps/oci-mirror/0.1.2/scripts/bootstrap-pki.sh
@@ -8,6 +8,7 @@ PUBLIC_HOST=${OCI_MIRROR_PUBLIC_HOST:-}
 EGRESS_CERTS=${OCI_MIRROR_MTLS_EGRESS_CERTS:-}
 CA_DAYS=${OCI_MIRROR_MTLS_CA_DAYS:-3650}
 LEAF_DAYS=${OCI_MIRROR_MTLS_LEAF_DAYS:-397}
+RENEW_BEFORE_DAYS=${OCI_MIRROR_MTLS_RENEW_BEFORE_DAYS:-30}
 GENERATE_GATEWAY_SERVER=${OCI_MIRROR_MTLS_GENERATE_GATEWAY_SERVER:-true}
 
 die() {
@@ -28,6 +29,11 @@ fi
 if [[ ! "$LEAF_DAYS" =~ ^[0-9]+$ ]] || ((10#$LEAF_DAYS < 30 || 10#$LEAF_DAYS > 825)); then
   die 'OCI_MIRROR_MTLS_LEAF_DAYS must be between 30 and 825'
 fi
+if [[ ! "$RENEW_BEFORE_DAYS" =~ ^[0-9]+$ ]] ||
+  ((10#$RENEW_BEFORE_DAYS < 1 || 10#$RENEW_BEFORE_DAYS >= 10#$LEAF_DAYS)); then
+  die 'OCI_MIRROR_MTLS_RENEW_BEFORE_DAYS must be at least 1 and lower than OCI_MIRROR_MTLS_LEAF_DAYS'
+fi
+RENEW_BEFORE_SECONDS=$((10#$RENEW_BEFORE_DAYS * 86400))
 
 valid_ipv4() {
   local value=$1
@@ -223,7 +229,7 @@ verify_existing_leaf() {
   [[ "$actual_sans" == "$(normalized_san_set "$expected_sans")" ]] || die "existing certificate SAN does not match requested identity: $cert"
   local purpose
   for purpose in "$@"; do
-    openssl verify -CAfile "$CA_CERT" -purpose "$purpose" "$cert" >/dev/null || die "certificate verification failed for $purpose: $cert"
+    openssl verify -no_check_time -CAfile "$CA_CERT" -purpose "$purpose" "$cert" >/dev/null || die "certificate verification failed for $purpose: $cert"
   done
 }
 
@@ -239,7 +245,9 @@ ensure_leaf() {
   fi
   if [[ -e "$key" && -e "$cert" ]]; then
     verify_existing_leaf "$key" "$cert" "$expected_san" "$@"
-    return
+    if openssl x509 -checkend "$RENEW_BEFORE_SECONDS" -in "$cert" -noout >/dev/null; then
+      return
+    fi
   fi
   [[ -s "$CA_KEY" ]] || die "nodes-ca.key is required to issue missing certificate: $cert"
   if [[ ! -e "$key" ]]; then
@@ -259,6 +267,7 @@ ensure_leaf() {
     -CAserial "$CA_SERIAL" -CAcreateserial -out "$cert_tmp" -extfile "$ext_tmp"
   chmod 0644 "$cert_tmp"
   mv "$cert_tmp" "$cert"
+  rm -f -- "$csr_tmp" "$ext_tmp"
   trap - RETURN
   verify_existing_leaf "$key" "$cert" "$expected_san" "$@"
 }

--- a/apps/oci-mirror/0.1.2/scripts/generate-cidr.sh
+++ b/apps/oci-mirror/0.1.2/scripts/generate-cidr.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 SOURCE_URL=https://ftp.apnic.net/stats/apnic/delegated-apnic-latest
 SOURCE_FILE=
 TARGET=
+REFRESH_AFTER_DAYS=
+REPLACING=false
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -19,6 +21,10 @@ while [[ $# -gt 0 ]]; do
       TARGET=$2
       shift 2
       ;;
+    --refresh-after-days)
+      REFRESH_AFTER_DAYS=$2
+      shift 2
+      ;;
     *)
       printf 'OCI Mirror CIDR: unknown argument: %s\n' "$1" >&2
       exit 2
@@ -27,10 +33,25 @@ while [[ $# -gt 0 ]]; do
 done
 
 [[ -n "$TARGET" ]] || { printf 'OCI Mirror CIDR: --target is required\n' >&2; exit 2; }
+if [[ -n "$REFRESH_AFTER_DAYS" ]] &&
+  { [[ ! "$REFRESH_AFTER_DAYS" =~ ^[0-9]+$ ]] || ((10#$REFRESH_AFTER_DAYS < 1 || 10#$REFRESH_AFTER_DAYS > 365)); }; then
+  printf 'OCI Mirror CIDR: --refresh-after-days must be between 1 and 365\n' >&2
+  exit 2
+fi
 if [[ -e "$TARGET" ]]; then
   [[ -s "$TARGET" ]] || { printf 'OCI Mirror CIDR: existing target is empty: %s\n' "$TARGET" >&2; exit 1; }
-  printf 'OCI Mirror CIDR: preserving existing file: %s\n' "$TARGET"
-  exit 0
+  if [[ -z "$REFRESH_AFTER_DAYS" ]]; then
+    printf 'OCI Mirror CIDR: preserving existing file: %s\n' "$TARGET"
+    exit 0
+  fi
+  command -v stat >/dev/null 2>&1 || { printf 'OCI Mirror CIDR: stat is required for managed refresh\n' >&2; exit 1; }
+  target_mtime=$(stat -c %Y "$TARGET")
+  now=$(date +%s)
+  if ((now - target_mtime < 10#$REFRESH_AFTER_DAYS * 86400)); then
+    printf 'OCI Mirror CIDR: preserving current managed file: %s\n' "$TARGET"
+    exit 0
+  fi
+  REPLACING=true
 fi
 
 command -v awk >/dev/null 2>&1 || { printf 'OCI Mirror CIDR: awk is required\n' >&2; exit 1; }
@@ -48,6 +69,7 @@ if [[ -n "$SOURCE_FILE" ]]; then
 else
   command -v curl >/dev/null 2>&1 || { printf 'OCI Mirror CIDR: curl is required for automatic APNIC download\n' >&2; exit 1; }
   curl --fail --location --silent --show-error --proto '=https' --tlsv1.2 \
+    --connect-timeout 15 --max-time 120 --max-filesize 33554432 \
     --output "$SOURCE_TMP" "$SOURCE_URL"
 fi
 
@@ -121,7 +143,10 @@ file_size=$(wc -c < "$STAGED")
 ((file_size <= 16777216)) || { printf 'OCI Mirror CIDR: generated file exceeds 16 MiB\n' >&2; exit 1; }
 
 chmod 0644 "$STAGED"
-if ! ln "$STAGED" "$TARGET" 2>/dev/null; then
+if [[ "$REPLACING" == true ]]; then
+  mv -f -- "$STAGED" "$TARGET"
+  printf 'OCI Mirror CIDR: refreshed %s prefixes at %s\n' "$line_count" "$TARGET"
+elif ! ln "$STAGED" "$TARGET" 2>/dev/null; then
   [[ -s "$TARGET" ]] || { printf 'OCI Mirror CIDR: target appeared but is invalid: %s\n' "$TARGET" >&2; exit 1; }
   printf 'OCI Mirror CIDR: preserving concurrently created file: %s\n' "$TARGET"
 else

--- a/apps/oci-mirror/0.1.2/scripts/init.sh
+++ b/apps/oci-mirror/0.1.2/scripts/init.sh
@@ -127,9 +127,9 @@ json_string_array() {
 
 parse_egress_source_addresses() {
   local input=$1
-  local entry address
+  local entry address canonical network_key
   local -a entries=() ipv4_sources=() ipv6_sources=()
-  local -A seen=()
+  local -A seen=() seen_ipv6_networks=()
 
   [[ -n "$input" ]] || die 'OCI_MIRROR_EGRESS_SOURCE_ADDRESSES must contain at least one IPv4 or IPv6 address'
   [[ "$input" != *$'\n'* && "$input" != *$'\r'* ]] || die 'OCI_MIRROR_EGRESS_SOURCE_ADDRESSES must be a comma-separated single-line list'
@@ -138,15 +138,27 @@ parse_egress_source_addresses() {
   (( ${#entries[@]} >= 1 && ${#entries[@]} <= 256 )) || die 'OCI_MIRROR_EGRESS_SOURCE_ADDRESSES must contain 1 to 256 addresses'
 
   for entry in "${entries[@]}"; do
+    canonical=''
     address="${entry#"${entry%%[![:space:]]*}"}"
     address="${address%"${address##*[![:space:]]}"}"
     [[ -n "$address" ]] || die 'OCI_MIRROR_EGRESS_SOURCE_ADDRESSES must not contain empty items'
     if valid_ipv4 "$address"; then
+      valid_public_source_ipv4 "$address" || die "OCI_MIRROR_EGRESS_SOURCE_ADDRESSES contains a non-public IPv4 address: $address"
       ipv4_sources+=("$address")
     elif valid_ipv6 "$address"; then
-      ipv6_sources+=("$address")
+      valid_public_source_ipv6 "$address" || die "OCI_MIRROR_EGRESS_SOURCE_ADDRESSES contains a non-public IPv6 address: $address"
+      canonical="$(canonical_ipv6 "$address")"
+      IFS=: read -r -a IPV6_CANONICAL_HEXTETS <<<"$canonical"
+      network_key="${IPV6_CANONICAL_HEXTETS[0]}:${IPV6_CANONICAL_HEXTETS[1]}:${IPV6_CANONICAL_HEXTETS[2]}:${IPV6_CANONICAL_HEXTETS[3]}"
+      [[ -z ${seen_ipv6_networks["$network_key"]+x} ]] ||
+        die "OCI_MIRROR_EGRESS_SOURCE_ADDRESSES contains IPv6 addresses from the same /64: $address"
+      seen_ipv6_networks["$network_key"]=1
+      ipv6_sources+=("$canonical")
     else
       die "OCI_MIRROR_EGRESS_SOURCE_ADDRESSES contains an invalid IPv4/IPv6 address: $address"
+    fi
+    if [[ -n "$canonical" ]]; then
+      address="$canonical"
     fi
     if [[ -n ${seen["$address"]+x} ]]; then
       die "OCI_MIRROR_EGRESS_SOURCE_ADDRESSES contains duplicate address: $address"
@@ -163,21 +175,162 @@ valid_private_or_loopback_ipv4() {
   awk -F. '$1 == 10 || $1 == 127 || ($1 == 172 && $2 >= 16 && $2 <= 31) || ($1 == 192 && $2 == 168) { exit 0 } { exit 1 }' <<<"$1"
 }
 
+valid_private_or_loopback_ipv6() {
+  valid_ipv6 "$1" || return 1
+  local first second third fourth
+  first=$((16#${IPV6_EXPANDED_HEXTETS[0]}))
+  second=$((16#${IPV6_EXPANDED_HEXTETS[1]}))
+  third=$((16#${IPV6_EXPANDED_HEXTETS[2]}))
+  fourth=$((16#${IPV6_EXPANDED_HEXTETS[3]}))
+  if ((first == 0 && second == 0 && third == 0 && fourth == 0)); then
+    ((16#${IPV6_EXPANDED_HEXTETS[4]} == 0 &&
+      16#${IPV6_EXPANDED_HEXTETS[5]} == 0 &&
+      16#${IPV6_EXPANDED_HEXTETS[6]} == 0 &&
+      16#${IPV6_EXPANDED_HEXTETS[7]} == 1))
+    return
+  fi
+  ((first >= 0xfc00 && first <= 0xfdff))
+}
+
+valid_private_or_loopback_ip() {
+  valid_private_or_loopback_ipv4 "$1" || valid_private_or_loopback_ipv6 "$1"
+}
+
+valid_listen_ip() {
+  valid_ipv4 "$1" || valid_ipv6 "$1"
+}
+
+listen_address() {
+  if [[ "$1" == *:* ]]; then
+    printf '[%s]:%s' "$1" "$2"
+  else
+    printf '%s:%s' "$1" "$2"
+  fi
+}
+
+canonical_ipv6() {
+  local value=$1
+  local hextet normalized separator='' result=''
+  valid_ipv6 "$value" || return 1
+  for hextet in "${IPV6_EXPANDED_HEXTETS[@]}"; do
+    printf -v normalized '%x' "$((16#$hextet))"
+    result+="${separator}${normalized}"
+    separator=:
+  done
+  printf '%s' "$result"
+}
+
+canonical_host() {
+  local value=$1
+  if valid_ipv4 "$value"; then
+    printf '%s' "$value"
+  elif valid_ipv6 "$value"; then
+    canonical_ipv6 "$value"
+  else
+    printf '%s' "${value,,}"
+  fi
+}
+
+valid_public_source_ipv4() {
+  local value=$1
+  local first second third
+  valid_ipv4 "$value" || return 1
+  IFS=. read -r first second third _ <<<"$value"
+  if ((
+    (first == 192 && second == 0 && third == 2) ||
+    (first == 198 && second == 51 && third == 100) ||
+    (first == 203 && second == 0 && third == 113)
+  )); then
+    return 0
+  fi
+  ((first > 0 && first < 224)) || return 1
+  ((first != 10 && first != 127)) || return 1
+  ! ((first == 100 && second >= 64 && second <= 127)) || return 1
+  ! ((first == 169 && second == 254)) || return 1
+  ! ((first == 172 && second >= 16 && second <= 31)) || return 1
+  ! ((first == 192 && (second == 0 || second == 88 || second == 168))) || return 1
+  ! ((first == 198 && (second == 18 || second == 19))) || return 1
+}
+
+valid_public_source_ipv6() {
+  local value=$1
+  valid_ipv6 "$value" || return 1
+  local first second third fourth fifth sixth seventh eighth embedded_ipv4
+  first=$((16#${IPV6_EXPANDED_HEXTETS[0]}))
+  second=$((16#${IPV6_EXPANDED_HEXTETS[1]}))
+  third=$((16#${IPV6_EXPANDED_HEXTETS[2]}))
+  fourth=$((16#${IPV6_EXPANDED_HEXTETS[3]}))
+  fifth=$((16#${IPV6_EXPANDED_HEXTETS[4]}))
+  sixth=$((16#${IPV6_EXPANDED_HEXTETS[5]}))
+  seventh=$((16#${IPV6_EXPANDED_HEXTETS[6]}))
+  eighth=$((16#${IPV6_EXPANDED_HEXTETS[7]}))
+  if ((first == 0 && second == 0 && third == 0 && fourth == 0)); then
+    return 1
+  fi
+
+  if ((first == 0x64 && second == 0xff9b && third == 0 && fourth == 0 && fifth == 0 && sixth == 0)); then
+    printf -v embedded_ipv4 '%d.%d.%d.%d' \
+      "$((seventh >> 8))" "$((seventh & 255))" "$((eighth >> 8))" "$((eighth & 255))"
+    if [[ "$embedded_ipv4" == 192.0.2.* || "$embedded_ipv4" == 198.51.100.* || "$embedded_ipv4" == 203.0.113.* ]]; then
+      return 1
+    fi
+    valid_public_source_ipv4 "$embedded_ipv4"
+    return
+  fi
+
+  ((first == 0x64 && second == 0xff9b && third == 1)) && return 1
+  ((first == 0x100 && second == 0 && third == 0 && fourth == 0)) && return 1
+  ((first == 0x100 && second == 0 && third == 0 && fourth == 1)) && return 1
+  if ((first == 0x2001 && second <= 0x1ff)); then
+    if ((second == 1 && third == 0 && fourth == 0 && fifth == 0 && sixth == 0 && seventh == 0 && (eighth == 1 || eighth == 2 || eighth == 3))) ||
+      ((second == 3)) ||
+      ((second == 4 && third == 0x112)) ||
+      ((second >= 0x20 && second <= 0x2f)) ||
+      ((second >= 0x30 && second <= 0x3f)); then
+      return 0
+    fi
+    return 1
+  fi
+  ((first >= 0x3ff0 && first <= 0x3fff)) && return 1
+  ((first == 0x2002)) && return 1
+  ((first == 0x5f00)) && return 1
+  ((first >= 0xfc00 && first <= 0xfdff)) && return 1
+  ((first >= 0xfe80 && first <= 0xfebf)) && return 1
+  ((first >= 0xff00 && first <= 0xffff)) && return 1
+  return 0
+}
+
 valid_dns_name() {
   [[ "$1" =~ ^[A-Za-z0-9]([A-Za-z0-9.-]*[A-Za-z0-9])?$ && "$1" != *..* ]]
 }
 
-valid_ipv4_cidr() {
+valid_ip_cidr() {
   local address=${1%%/*}
   local prefix=32
   if [[ "$1" == */* ]]; then
     prefix=${1##*/}
   fi
-  valid_ipv4 "$address" && [[ "$prefix" =~ ^[0-9]+$ ]] && ((10#$prefix >= 0 && 10#$prefix <= 32))
+  if valid_ipv4 "$address"; then
+    [[ "$prefix" =~ ^[0-9]+$ ]] && ((10#$prefix >= 0 && 10#$prefix <= 32))
+  else
+    valid_ipv6 "$address" && [[ "$prefix" =~ ^[0-9]+$ ]] && ((10#$prefix >= 0 && 10#$prefix <= 128))
+  fi
 }
 
-valid_allowlist() {
-  [[ -z "$1" || "$1" =~ ^[A-Fa-f0-9.:/]+$ ]]
+parse_ip_allowlist() {
+  local input=$1 entry normalized
+  local -a entries=() values=()
+  [[ -z "$input" ]] && { ALLOWLIST_JSON='[]'; return; }
+  [[ "$input" != *$'\n'* && "$input" != *$'\r'* ]] || die 'OCI_MIRROR_IP_ALLOWLIST must be a comma-separated single-line list'
+  IFS=',' read -r -a entries <<<"$input"
+  (( ${#entries[@]} >= 1 && ${#entries[@]} <= 4096 )) || die 'OCI_MIRROR_IP_ALLOWLIST must contain 1 to 4096 entries'
+  for entry in "${entries[@]}"; do
+    normalized="${entry#"${entry%%[![:space:]]*}"}"
+    normalized="${normalized%"${normalized##*[![:space:]]}"}"
+    valid_ip_cidr "$normalized" || die "OCI_MIRROR_IP_ALLOWLIST contains an invalid IP/CIDR entry: $normalized"
+    values+=("$normalized")
+  done
+  ALLOWLIST_JSON="$(json_string_array "${values[@]}")"
 }
 
 valid_bearer_token() {
@@ -194,6 +347,12 @@ valid_private_http_origin() {
   local value=$1
   local host
   local port
+  if [[ "$value" =~ ^http://\[([0-9A-Fa-f:]+)\]:([0-9]+)$ ]]; then
+    host=${BASH_REMATCH[1]}
+    port=${BASH_REMATCH[2]}
+    valid_private_or_loopback_ipv6 "$host" && valid_port "$port"
+    return
+  fi
   [[ "$value" =~ ^http://([^/:]+):([0-9]+)$ ]] || return 1
   host=${BASH_REMATCH[1]}
   port=${BASH_REMATCH[2]}
@@ -212,7 +371,7 @@ valid_https_origin() {
   if [[ "$value" =~ ^https://\[([0-9A-Fa-f:]+)\]:([0-9]+)$ ]]; then
     host=${BASH_REMATCH[1]}
     port=${BASH_REMATCH[2]}
-    [[ "$host" == *:* ]] || return 1
+    valid_ipv6 "$host" || return 1
   elif [[ "$value" =~ ^https://([^/:]+):([0-9]+)$ ]]; then
     host=${BASH_REMATCH[1]}
     port=${BASH_REMATCH[2]}
@@ -256,41 +415,65 @@ stage_runtime_pki() {
   local required_prefix=$2
   local trust_mode=$3
   local candidate
-  rm -rf -- "$ROOT_DIR/config/pki"
-  install -d -m 0750 "$ROOT_DIR/config/pki"
-  install -m 0644 "$source_dir/nodes-ca.crt" "$ROOT_DIR/config/pki/nodes-ca.crt"
+  rm -rf -- "$CONFIG_STAGE/pki"
+  install -d -m 0750 "$CONFIG_STAGE/pki"
+  install -m 0644 "$source_dir/nodes-ca.crt" "$CONFIG_STAGE/pki/nodes-ca.crt"
   if [[ "$trust_mode" == node ]]; then
-    install -m 0644 "$source_dir/trust-bundle.crt" "$ROOT_DIR/config/pki/trust-bundle.crt"
+    install -m 0644 "$source_dir/trust-bundle.crt" "$CONFIG_STAGE/pki/trust-bundle.crt"
   else
     for candidate in \
       /etc/ssl/certs/ca-certificates.crt \
       /etc/pki/tls/certs/ca-bundle.crt \
       /etc/ssl/ca-bundle.pem; do
       if [[ -s "$candidate" ]]; then
-        install -m 0644 "$candidate" "$ROOT_DIR/config/pki/trust-bundle.crt"
+        install -m 0644 "$candidate" "$CONFIG_STAGE/pki/trust-bundle.crt"
         break
       fi
     done
-    [[ -s "$ROOT_DIR/config/pki/trust-bundle.crt" ]] || die 'a system CA bundle is required for HTTPS upstream connections'
+    [[ -s "$CONFIG_STAGE/pki/trust-bundle.crt" ]] || die 'a system CA bundle is required for HTTPS upstream connections'
   fi
-  install -m 0600 "$source_dir/$required_prefix.key" "$ROOT_DIR/config/pki/$required_prefix.key"
-  install -m 0644 "$source_dir/$required_prefix.crt" "$ROOT_DIR/config/pki/$required_prefix.crt"
+  install -m 0600 "$source_dir/$required_prefix.key" "$CONFIG_STAGE/pki/$required_prefix.key"
+  install -m 0644 "$source_dir/$required_prefix.crt" "$CONFIG_STAGE/pki/$required_prefix.crt"
 }
 
 stage_system_trust_bundle() {
   local candidate
-  rm -rf -- "$ROOT_DIR/config/pki"
+  rm -rf -- "$CONFIG_STAGE/pki"
   for candidate in \
     /etc/ssl/certs/ca-certificates.crt \
     /etc/pki/tls/certs/ca-bundle.crt \
     /etc/ssl/ca-bundle.pem; do
     if [[ -s "$candidate" ]]; then
-      install -d -m 0750 "$ROOT_DIR/config/pki"
-      install -m 0644 "$candidate" "$ROOT_DIR/config/pki/trust-bundle.crt"
+      install -d -m 0750 "$CONFIG_STAGE/pki"
+      install -m 0644 "$candidate" "$CONFIG_STAGE/pki/trust-bundle.crt"
       return
     fi
   done
   die 'a system CA bundle is required for HTTPS upstream connections'
+}
+
+publish_config() {
+  local backup_dir had_existing=false
+  backup_dir="$(mktemp -d "$ROOT_DIR/.oci-mirror-config-backup.XXXXXX")"
+  if [[ -e "$CONFIG_DIR" ]]; then
+    mv -- "$CONFIG_DIR" "$backup_dir/config"
+    had_existing=true
+  fi
+  if ! mv -- "$CONFIG_STAGE" "$CONFIG_DIR"; then
+    if [[ "$had_existing" == true ]]; then
+      mv -- "$backup_dir/config" "$CONFIG_DIR"
+    fi
+    rmdir -- "$backup_dir" 2>/dev/null || true
+    die 'failed to publish generated configuration'
+  fi
+  CONFIG_STAGE=
+  rm -rf -- "$backup_dir"
+}
+
+cleanup_config_stage() {
+  if [[ -n ${CONFIG_STAGE:-} && -d "$CONFIG_STAGE" ]]; then
+    rm -rf -- "$CONFIG_STAGE"
+  fi
 }
 
 safe_data_dir() {
@@ -302,6 +485,9 @@ safe_data_dir() {
 }
 
 CIDR_SOURCE_PATTERN='^[A-Za-z0-9._:/ -]+$'
+CONFIG_DIR="$ROOT_DIR/config"
+CONFIG_STAGE=
+trap cleanup_config_stage EXIT
 
 ROLE="$(read_env OCI_MIRROR_ROLE)"
 ROLE="${ROLE,,}"
@@ -330,13 +516,20 @@ safe_data_dir "$DATA_DIR" || die 'OCI_MIRROR_DATA_DIR is too broad'
 safe_data_dir "$PKI_DIR" || die 'OCI_MIRROR_PKI_DIR is too broad'
 [[ "$DATA_DIR" != "$ROOT_DIR" && "$DATA_DIR" != "$ROOT_DIR/config" && "$DATA_DIR" != "$ROOT_DIR/config/"* ]] || die 'OCI_MIRROR_DATA_DIR must not point to the application or its config directory'
 [[ "$PKI_DIR" != "$ROOT_DIR" && "$PKI_DIR" != "$ROOT_DIR/config" && "$PKI_DIR" != "$ROOT_DIR/config/"* ]] || die 'OCI_MIRROR_PKI_DIR must not point to the application or its config directory'
+[[ "$PKI_DIR" != "$DATA_DIR" && "$PKI_DIR" != "$DATA_DIR/"* ]] || die 'OCI_MIRROR_PKI_DIR must not be the data directory or one of its subdirectories'
+[[ "$DATA_DIR" != "$PKI_DIR" && "$DATA_DIR" != "$PKI_DIR/"* ]] || die 'OCI_MIRROR_DATA_DIR must not be the PKI directory or one of its subdirectories'
+[[ ! -L "$CONFIG_DIR" ]] || die 'the generated config directory must not be a symbolic link'
 valid_node_id "$GATEWAY_ID" || die 'OCI_MIRROR_MTLS_GATEWAY_ID must match ^[a-z][a-z0-9_-]{0,31}$'
 
-install -d -m 0750 "$ROOT_DIR/config" "$ROOT_DIR/config/tls" "$DATA_DIR"
+install -d -m 0750 "$DATA_DIR"
+CONFIG_STAGE="$(mktemp -d "$ROOT_DIR/.oci-mirror-config.XXXXXX")"
+install -d -m 0750 "$CONFIG_STAGE/tls"
 stage_system_trust_bundle
 
 if [[ "$ROLE" == gateway ]]; then
   MANAGEMENT_IP="$(read_env OCI_MIRROR_GATEWAY_MANAGEMENT_IP)"
+  GATEWAY_LISTEN_IP="$(read_env OCI_MIRROR_GATEWAY_LISTEN_IP)"
+  GATEWAY_LISTEN_IP="${GATEWAY_LISTEN_IP:-0.0.0.0}"
   MANAGEMENT_PORT="$(read_env PANEL_APP_PORT_MANAGEMENT)"
   PUBLIC_HOST="$(read_env OCI_MIRROR_PUBLIC_HOST)"
   EGRESS_PROXY_URL="$(read_env OCI_MIRROR_EGRESS_PROXY_URL)"
@@ -345,18 +538,22 @@ if [[ "$ROLE" == gateway ]]; then
   CIDR_FILE="$(read_env OCI_MIRROR_CHINA_CIDR_FILE)"
   CIDR_SOURCE="$(read_env OCI_MIRROR_CHINA_CIDR_SOURCE)"
   CIDR_UPDATED="$(read_env OCI_MIRROR_CHINA_CIDR_UPDATED)"
+  CIDR_REFRESH_DAYS="$(read_env OCI_MIRROR_CHINA_CIDR_REFRESH_DAYS)"
+  CIDR_REFRESH_DAYS="${CIDR_REFRESH_DAYS:-30}"
   TLS_ENABLED="$(read_env OCI_MIRROR_TLS_ENABLED)"
   TLS_ENABLED="${TLS_ENABLED:-true}"
   TLS_ENABLED="${TLS_ENABLED,,}"
   TLS_DIR="$(read_env OCI_MIRROR_TLS_DIR)"
+  MTLS_RENEW_BEFORE_DAYS="$(read_env OCI_MIRROR_MTLS_RENEW_BEFORE_DAYS)"
   MANAGEMENT_TOKEN="$(read_env OCI_MIRROR_MANAGEMENT_TOKEN)"
 
-  valid_private_or_loopback_ipv4 "$MANAGEMENT_IP" || die 'OCI_MIRROR_GATEWAY_MANAGEMENT_IP must be a private or loopback IPv4 address assigned to this host'
+  valid_listen_ip "$GATEWAY_LISTEN_IP" || die 'OCI_MIRROR_GATEWAY_LISTEN_IP must be an IPv4 or IPv6 address'
+  valid_private_or_loopback_ip "$MANAGEMENT_IP" || die 'OCI_MIRROR_GATEWAY_MANAGEMENT_IP must be a private or loopback IPv4/IPv6 address assigned to this host'
   valid_port "$MANAGEMENT_PORT" || die 'PANEL_APP_PORT_MANAGEMENT must be a valid port for the Gateway role'
   [[ "$SERVICE_PORT" != "$MANAGEMENT_PORT" ]] || die 'Gateway public and management ports must be different'
-  if ! valid_ipv4 "$PUBLIC_HOST"; then
+  if ! valid_ipv4 "$PUBLIC_HOST" && ! valid_ipv6 "$PUBLIC_HOST"; then
     if ! valid_dns_name "$PUBLIC_HOST" || [[ "$PUBLIC_HOST" != *.* ]]; then
-      die 'OCI_MIRROR_PUBLIC_HOST must be a DNS hostname or IPv4 address'
+      die 'OCI_MIRROR_PUBLIC_HOST must be a DNS hostname or IPv4/IPv6 address'
     fi
   fi
   if [[ "$TRANSPORT_MODE" == private ]]; then
@@ -365,9 +562,18 @@ if [[ "$ROLE" == gateway ]]; then
     valid_https_origin "$EGRESS_PROXY_URL" || die 'OCI_MIRROR_EGRESS_PROXY_URL must be an HTTPS origin with an explicit port for mTLS'
   fi
   parse_egress_source_addresses "$SOURCE_ADDRESSES"
-  valid_allowlist "$IP_ALLOWLIST" || die 'OCI_MIRROR_IP_ALLOWLIST must contain one IP address or CIDR'
-  CIDR_FILE="$(absolute_path "${CIDR_FILE:-$DATA_DIR/china-mainland.cidr}")"
-  bash "$ROOT_DIR/scripts/generate-cidr.sh" --target "$CIDR_FILE"
+  parse_ip_allowlist "$IP_ALLOWLIST"
+  if [[ ! "$CIDR_REFRESH_DAYS" =~ ^[0-9]+$ ]] ||
+    ((10#$CIDR_REFRESH_DAYS < 1 || 10#$CIDR_REFRESH_DAYS > 365)); then
+    die 'OCI_MIRROR_CHINA_CIDR_REFRESH_DAYS must be between 1 and 365'
+  fi
+  if [[ -n "$CIDR_FILE" ]]; then
+    CIDR_FILE="$(absolute_path "$CIDR_FILE")"
+    bash "$ROOT_DIR/scripts/generate-cidr.sh" --target "$CIDR_FILE"
+  else
+    CIDR_FILE="$DATA_DIR/china-mainland.cidr"
+    bash "$ROOT_DIR/scripts/generate-cidr.sh" --target "$CIDR_FILE" --refresh-after-days "$CIDR_REFRESH_DAYS"
+  fi
   [[ -s "$CIDR_FILE" ]] || die "CIDR file does not exist or is empty: $CIDR_FILE"
   CIDR_SOURCE="${CIDR_SOURCE:-https://ftp.apnic.net/stats/apnic/delegated-apnic-latest}"
   CIDR_UPDATED="${CIDR_UPDATED:-$(date -u -r "$CIDR_FILE" +%F)}"
@@ -377,18 +583,30 @@ if [[ "$ROLE" == gateway ]]; then
   [[ "$TRANSPORT_MODE" != mtls || "$TLS_ENABLED" == true ]] || die 'mTLS transport requires Gateway TLS to be enabled'
   valid_bearer_token "$MANAGEMENT_TOKEN" || die 'OCI_MIRROR_MANAGEMENT_TOKEN must be 32 to 4096 bytes using A-Z, a-z, 0-9, . _ ~ + / -, with optional trailing = padding for the Gateway role'
   [[ "$MANAGEMENT_TOKEN" != "$EGRESS_TOKEN" ]] || die 'management and Egress tokens must be different'
+  if [[ "$TLS_ENABLED" == true && -n "$TLS_DIR" ]]; then
+    TLS_DIR="$(absolute_path "$TLS_DIR")"
+    if [[ "$TLS_DIR" != "$PKI_DIR/gateway" ]]; then
+      [[ -f "$TLS_DIR/server.crt" && -f "$TLS_DIR/server.key" ]] || die 'TLS directory must contain server.crt and server.key'
+    fi
+  elif [[ "$TLS_ENABLED" == true && "$TRANSPORT_MODE" != mtls ]]; then
+    die 'OCI_MIRROR_TLS_DIR is required when Gateway TLS is enabled outside mTLS mode'
+  fi
 
   if [[ "$TRANSPORT_MODE" == mtls ]]; then
     GATEWAY_TRANSPORT_JSON=$(cat <<EOF
 {"mode":"mtls","ca_file":"/etc/oci-mirror/pki/nodes-ca.crt","cert_file":"/etc/oci-mirror/pki/gateway-client.crt","key_file":"/etc/oci-mirror/pki/gateway-client.key","peer_spiffe_id":"spiffe://oci-mirror/egress/${NODE_ID}"}
 EOF
 )
+    cert_host="$(certificate_host_for_node "$NODE_ID" "$EGRESS_CERTS")" || die 'OCI_MIRROR_MTLS_EGRESS_CERTS must include the selected Egress node ID'
+    [[ "$(canonical_host "$cert_host")" == "$(canonical_host "$(origin_host "$EGRESS_PROXY_URL")")" ]] || die 'selected Egress certificate SAN host must match the Egress proxy URL host'
     export OCI_MIRROR_PKI_DIR="$PKI_DIR"
     export OCI_MIRROR_MTLS_GATEWAY_ID="$GATEWAY_ID"
     export OCI_MIRROR_PUBLIC_HOST="$PUBLIC_HOST"
     export OCI_MIRROR_MTLS_EGRESS_CERTS="$EGRESS_CERTS"
+    if [[ -n "$MTLS_RENEW_BEFORE_DAYS" ]]; then
+      export OCI_MIRROR_MTLS_RENEW_BEFORE_DAYS="$MTLS_RENEW_BEFORE_DAYS"
+    fi
     if [[ -n "$TLS_DIR" ]]; then
-      TLS_DIR="$(absolute_path "$TLS_DIR")"
       if [[ "$TLS_DIR" == "$PKI_DIR/gateway" ]]; then
         export OCI_MIRROR_MTLS_GENERATE_GATEWAY_SERVER=true
       else
@@ -399,44 +617,35 @@ EOF
       export OCI_MIRROR_MTLS_GENERATE_GATEWAY_SERVER=true
     fi
     bash "$ROOT_DIR/scripts/bootstrap-pki.sh"
-    cert_host="$(certificate_host_for_node "$NODE_ID" "$EGRESS_CERTS")" || die 'OCI_MIRROR_MTLS_EGRESS_CERTS must include the selected Egress node ID'
-    [[ "${cert_host,,}" == "$(origin_host "$EGRESS_PROXY_URL")" ]] || die 'selected Egress certificate SAN host must match the Egress proxy URL host'
     stage_runtime_pki "$PKI_DIR/gateway" gateway-client system
   else
     GATEWAY_TRANSPORT_JSON='{"mode":"private"}'
   fi
 
-  ALLOWLIST_JSON='[]'
-  if [[ -n "$IP_ALLOWLIST" ]]; then
-    [[ "$IP_ALLOWLIST" != *'"'* && "$IP_ALLOWLIST" != *$'\n'* ]] || die 'OCI_MIRROR_IP_ALLOWLIST contains invalid characters'
-    ALLOWLIST_JSON="[\"$IP_ALLOWLIST\"]"
-  fi
-
   TLS_JSON=''
   if [[ "$TLS_ENABLED" == true ]]; then
     [[ -n "$TLS_DIR" ]] || die 'OCI_MIRROR_TLS_DIR is required when Gateway TLS is enabled'
-    TLS_DIR="$(absolute_path "$TLS_DIR")"
     [[ -f "$TLS_DIR/server.crt" && -f "$TLS_DIR/server.key" ]] || die 'TLS directory must contain server.crt and server.key'
-    install -m 0644 "$TLS_DIR/server.crt" "$ROOT_DIR/config/tls/server.crt"
-    install -m 0600 "$TLS_DIR/server.key" "$ROOT_DIR/config/tls/server.key"
+    install -m 0644 "$TLS_DIR/server.crt" "$CONFIG_STAGE/tls/server.crt"
+    install -m 0600 "$TLS_DIR/server.key" "$CONFIG_STAGE/tls/server.key"
     TLS_JSON=$'    "tls_cert_file": "/etc/oci-mirror/tls/server.crt",\n    "tls_key_file": "/etc/oci-mirror/tls/server.key",'
   else
-    rm -f -- "$ROOT_DIR/config/tls/server.crt" "$ROOT_DIR/config/tls/server.key"
+    rm -f -- "$CONFIG_STAGE/tls/server.crt" "$CONFIG_STAGE/tls/server.key"
   fi
 
-  if [[ "$(realpath -m -- "$CIDR_FILE")" != "$(realpath -m -- "$ROOT_DIR/config/china-mainland.cidr")" ]]; then
-    install -m 0644 "$CIDR_FILE" "$ROOT_DIR/config/china-mainland.cidr"
+  if [[ "$(realpath -m -- "$CIDR_FILE")" != "$(realpath -m -- "$CONFIG_STAGE/china-mainland.cidr")" ]]; then
+    install -m 0644 "$CIDR_FILE" "$CONFIG_STAGE/china-mainland.cidr"
   fi
   chown 65532:65532 "$DATA_DIR"
 
-  cat > "$ROOT_DIR/config/runtime.json" <<EOF
+  cat > "$CONFIG_STAGE/runtime.json" <<EOF
 {
   "gateway": {
-    "listen": "0.0.0.0:${SERVICE_PORT}",
+    "listen": "$(listen_address "$GATEWAY_LISTEN_IP" "$SERVICE_PORT")",
     "data_dir": "/var/lib/oci-mirror",
 ${TLS_JSON}
     "management": {
-      "listen": "${MANAGEMENT_IP}:${MANAGEMENT_PORT}",
+      "listen": "$(listen_address "$MANAGEMENT_IP" "$MANAGEMENT_PORT")",
       "token_env": "OCI_MIRROR_MANAGEMENT_TOKEN",
       "public_admin": false
     },
@@ -510,21 +719,21 @@ else
   GATEWAY_ALLOWED_PEER="$(read_env OCI_MIRROR_GATEWAY_ALLOWED_PEER)"
 
   if [[ "$TRANSPORT_MODE" == private ]]; then
-    valid_private_or_loopback_ipv4 "$EGRESS_LISTEN_IP" || die 'OCI_MIRROR_EGRESS_LISTEN_IP must be a private or loopback IPv4 address assigned to this host'
-    valid_private_http_origin "$GATEWAY_MANAGEMENT_URL" || die 'OCI_MIRROR_GATEWAY_MANAGEMENT_URL must be an HTTP origin on a private IPv4 address or private DNS name with an explicit port'
-    valid_ipv4_cidr "$GATEWAY_ALLOWED_PEER" || die 'OCI_MIRROR_GATEWAY_ALLOWED_PEER must be one IPv4 address or CIDR'
+    valid_private_or_loopback_ip "$EGRESS_LISTEN_IP" || die 'OCI_MIRROR_EGRESS_LISTEN_IP must be a private or loopback IPv4/IPv6 address assigned to this host'
+    valid_private_http_origin "$GATEWAY_MANAGEMENT_URL" || die 'OCI_MIRROR_GATEWAY_MANAGEMENT_URL must be an HTTP origin on a private IP address or private DNS name with an explicit port'
+    valid_ip_cidr "$GATEWAY_ALLOWED_PEER" || die 'OCI_MIRROR_GATEWAY_ALLOWED_PEER must be one IPv4/IPv6 address or CIDR'
   else
-    valid_ipv4 "$EGRESS_LISTEN_IP" || die 'OCI_MIRROR_EGRESS_LISTEN_IP must be an IPv4 listen address for mTLS'
+    valid_listen_ip "$EGRESS_LISTEN_IP" || die 'OCI_MIRROR_EGRESS_LISTEN_IP must be an IPv4 or IPv6 listen address for mTLS'
     valid_https_origin "$GATEWAY_MANAGEMENT_URL" || die 'OCI_MIRROR_GATEWAY_MANAGEMENT_URL must be an HTTPS origin with an explicit port for mTLS'
     if [[ -n "$GATEWAY_ALLOWED_PEER" ]]; then
-      valid_ipv4_cidr "$GATEWAY_ALLOWED_PEER" || die 'OCI_MIRROR_GATEWAY_ALLOWED_PEER must be one IPv4 address or CIDR when provided'
+      valid_ip_cidr "$GATEWAY_ALLOWED_PEER" || die 'OCI_MIRROR_GATEWAY_ALLOWED_PEER must be one IPv4/IPv6 address or CIDR when provided'
     fi
     NODE_DIR="$PKI_DIR/egress/$NODE_ID"
     [[ -s "$NODE_DIR/nodes-ca.crt" && -s "$NODE_DIR/trust-bundle.crt" && -s "$NODE_DIR/egress-node.key" && -s "$NODE_DIR/egress-node.crt" ]] || die 'Egress mTLS bundle is missing; generate it on Gateway and copy the selected egress directory to OCI_MIRROR_PKI_DIR'
     stage_runtime_pki "$NODE_DIR" egress-node node
   fi
 
-  rm -f -- "$ROOT_DIR/config/china-mainland.cidr" "$ROOT_DIR/config/tls/server.crt" "$ROOT_DIR/config/tls/server.key"
+  rm -f -- "$CONFIG_STAGE/china-mainland.cidr" "$CONFIG_STAGE/tls/server.crt" "$CONFIG_STAGE/tls/server.key"
   if [[ "$TRANSPORT_MODE" == mtls ]]; then
     GATEWAY_TRANSPORT_JSON=$(cat <<EOF
 {"mode":"mtls","ca_file":"/etc/oci-mirror/pki/nodes-ca.crt","cert_file":"/etc/oci-mirror/pki/egress-node.crt","key_file":"/etc/oci-mirror/pki/egress-node.key","peer_spiffe_id":"spiffe://oci-mirror/gateway/${GATEWAY_ID}"}
@@ -538,11 +747,11 @@ EOF
     GATEWAY_TRANSPORT_JSON='{"mode":"private"}'
     ALLOWED_PEERS_JSON="[\"$GATEWAY_ALLOWED_PEER\"]"
   fi
-  cat > "$ROOT_DIR/config/runtime.json" <<EOF
+  cat > "$CONFIG_STAGE/runtime.json" <<EOF
 {
   "egress": {
     "node_id": "${NODE_ID}",
-    "listen": "${EGRESS_LISTEN_IP}:${SERVICE_PORT}",
+    "listen": "$(listen_address "$EGRESS_LISTEN_IP" "$SERVICE_PORT")",
     "token_env": "OCI_MIRROR_EGRESS_TOKEN",
     "allowed_peers": ${ALLOWED_PEERS_JSON},
     "snapshot_url": "${GATEWAY_MANAGEMENT_URL}/v1/egress/nodes/${NODE_ID}/snapshot",
@@ -555,5 +764,6 @@ EOF
 EOF
 fi
 
-chmod 0640 "$ROOT_DIR/config/runtime.json"
-chown -R 65532:65532 "$ROOT_DIR/config"
+chmod 0640 "$CONFIG_STAGE/runtime.json"
+chown -R 65532:65532 "$CONFIG_STAGE"
+publish_config

--- a/apps/oci-mirror/README.md
+++ b/apps/oci-mirror/README.md
@@ -2,7 +2,7 @@
 
 ## 产品介绍
 
-OCI Mirror 是一个只读 OCI 拉取缓存和固定源代理。Gateway 负责公网入口、访问策略、配额、缓存和调度；Egress 负责从独立出口节点连接 Docker Hub。同一个应用包可分别安装为 Gateway 或 Egress，默认使用 mTLS 保护公网节点间通信。
+OCI Mirror 是一个只读 OCI 拉取缓存和固定源代理。Gateway 负责公网入口、访问策略、配额、缓存和调度；Egress 负责从独立出口节点连接上游。本商店包是面向单个 Egress 节点和 Docker Hub 的安装预设；上游支持的多 Egress、多 Registry 和自定义固定源代理需要直接维护上游配置文件。同一个应用包可分别安装为 Gateway 或 Egress，默认使用 mTLS 保护公网节点间通信。
 
 ## 主要功能
 
@@ -26,7 +26,9 @@ Docker 客户端 -> Gateway 公网 TLS -> Egress 公网 mTLS -> Docker Hub
 3. 再安装 `Egress` 角色；两次安装必须使用相同的 Gateway 身份 ID、Egress 节点 ID 和 Egress Token。
 4. Gateway 的 `Egress 代理 URL` 填 Egress 的公网 HTTPS 地址，例如 `https://egress.example.com:8443`。
 5. Egress 的 `Gateway 快照 URL` 填 Gateway 的公网 HTTPS 地址，例如 `https://mirror.example.com:8443`。mTLS 模式不使用 Gateway 私有管理端口拉取快照。
-6. `Egress 公网源地址` 填写已分配或路由到 Egress 主机的具体公网 IPv4/IPv6 地址，多个地址使用英文逗号分隔。Gateway 使用它生成出口池；受 1Panel 单表单无条件必填的限制，安装 Egress 角色时也需填写，但 Egress 运行配置不会直接使用它。
+6. 安装 Gateway 时，`Egress 公网源地址` 填写已分配或路由到 Egress 主机的具体公网 IPv4/IPv6 地址，多个地址使用英文逗号分隔。安装 Egress 时留空该字段和 `Gateway 管理 Token`；Egress 只需要自己的节点 Token。
+
+监听地址可使用 IPv4 或 IPv6。URL 中的 IPv6 必须使用方括号，例如 `https://[2001:db8::10]:8443`；监听配置会生成 `[::]:8443` 形式。`Gateway 公网监听 IP` 控制 Registry 和 mTLS 快照入口，`Gateway 管理监听 IP` 只用于私有管理接口。
 
 应用不限制同一主机的安装数量。Gateway 与 Egress 可以安装在同一主机，但必须使用不同服务端口；由于 1Panel 会把所有 `paramPort` 表单值都纳入端口占用检查，两次安装还必须填写不同的 `Gateway 管理端口` 占位值，即使 Egress 不使用该端口。需要共享自动生成的证书时，两次安装应填写同一个绝对 `OCI_MIRROR_PKI_DIR`。相对路径按各自应用安装目录解析，不会自动共享。
 
@@ -43,25 +45,28 @@ Docker 客户端 -> Gateway 公网 TLS -> Egress 公网 mTLS -> Docker Hub
 - 增加清单项只创建缺失的证书；减少清单项不会删除旧目录；修改已有节点的 DNS/IP 会失败而不是覆盖私钥和证书。
 - CA 私钥仅保存在 `OCI_MIRROR_PKI_DIR/authority/`，不会复制进容器配置。远端 Egress 只需要自己的 `egress/<节点 ID>/` 目录，不能复制 `authority/nodes-ca.key`。
 - Gateway 留空 `Gateway TLS 源目录` 时会生成覆盖 `Registry 主机名` 的服务证书。该证书由节点 CA 签发，Docker 客户端需要信任 `authority/nodes-ca.crt`；也可以提供受公网 CA 信任的 `server.crt` 和 `server.key`。
+- 初始化时会在叶证书剩余有效期不足 30 天时使用原私钥重新签发。Gateway 续期后，必须把更新后的对应 Egress 证书包重新复制到远端节点；可在 `.env` 中用 `OCI_MIRROR_MTLS_RENEW_BEFORE_DAYS` 调整续期窗口。
 - 当前 Gateway 运行配置只启用表单选择的一个 Egress 节点；额外证书包用于后续节点部署，不会自动扩展 Gateway 的节点调度配置。
 
 ## CIDR 数据
 
 - `中国大陆 CIDR 文件` 留空时，Gateway 首次初始化会下载 APNIC delegated 数据并生成 `OCI_MIRROR_DATA_DIR/china-mainland.cidr`。
-- 已存在且非空的 CIDR 文件会原样保留，不会在升级或重新初始化时自动覆盖。
+- 自动生成的文件超过 `托管 CIDR 刷新间隔` 后会在下一次初始化或升级时原子刷新，默认 30 天；下载或解析失败时保留旧文件。
+- 明确填写的自定义 CIDR 文件不会自动刷新或覆盖。
 - 自动生成需要安装主机能够通过 HTTPS 访问 APNIC；离线环境应预先提供经过验证的 IPv4/IPv6 CIDR 文件。
 - APNIC 自动数据的来源和更新日期由初始化脚本生成，不在 1Panel 安装表单中重复询问。单独使用 Compose 时可在 `.env` 中覆盖这两项元数据。
 
 ## 私网模式
 
-WireGuard 或可信内网部署可把传输模式改为 `private`。此时 `Egress 代理 URL` 和 `Gateway 快照 URL` 必须使用私有地址的 `http://` URL，Egress 监听 IP 必须是私有或回环 IPv4，`Gateway IP/CIDR 限制`必须填写 Gateway 的私网地址段。private 模式不能把 Bearer Token 当作公网传输保护。
+WireGuard 或可信内网部署可把传输模式改为 `private`。此时 `Egress 代理 URL` 和 `Gateway 快照 URL` 必须使用私有地址的 `http://` URL，Egress 监听 IP 必须是私有或回环 IPv4/IPv6，`Gateway IP/CIDR 限制`必须填写 Gateway 的私网地址段。private 模式不能把 Bearer Token 当作公网传输保护。
 
 ## 持久化与升级
 
 - Gateway 的 SQLite、缓存对象、用量和健康状态保存在 `OCI_MIRROR_DATA_DIR` 宿主机目录。
 - Egress 不保存业务数据；Compose 保留相同数据挂载以维持单一服务模板，但 Egress 运行模式不会使用该目录。
+- mTLS PKI 目录必须与数据目录分离，不能等于数据目录或位于其内部，避免 CA 私钥进入 Gateway 数据挂载。
 - 备份 Gateway 时同时保存数据目录、CIDR 文件、TLS/mTLS 证书和安装表单参数。不要在 Gateway 运行时单独复制或删除 SQLite WAL 文件。
-- `init.sh` 与 `upgrade.sh` 会按当前角色和表单重新生成 `config/runtime.json`；手工修改生成配置不属于稳定升级接口。
+- `init.sh` 与 `upgrade.sh` 会按当前角色和表单原子替换生成配置；校验或生成失败时保留上一份可用配置。手工修改 `config/runtime.json` 不属于稳定升级接口。
 
 ## 安全与部署风险
 
@@ -69,11 +74,11 @@ WireGuard 或可信内网部署可把传输模式改为 `private`。此时 `Egre
 
 host network 是上游绑定真实出口源地址、私网控制地址及 Gateway 公网监听器的核心要求，不能移除。应用保留只读根文件系统、非 root UID `65532`、`cap_drop: ALL` 和 `no-new-privileges`，不挂载 Docker Socket，也不启用 privileged 模式。商店包固定使用 `/tmp` 工作目录，因为上游程序拒绝把持久化状态目录作为进程工作目录；上游 Compose 的 `pids_limit` 与 1Panel 自动注入的资源限制冲突，因此商店包不重复声明该字段。
 
-Gateway 管理 Token 与每个 Egress Token 必须互不相同，长度为 32-4096 字节，仅允许 `A-Z a-z 0-9 . _ ~ + / -`，`=` 只能作为末尾填充。可用 `openssl rand -base64 48 | tr -d '\n'` 分别生成。Gateway 管理监听器默认绑定 `127.0.0.1`；公网 mTLS 节点通过 Gateway 公网监听器的受证书保护快照路径通信，不应把私有管理端口暴露到公网。
+Gateway 管理 Token 与每个 Egress Token 必须互不相同，长度为 32-4096 字节，仅允许 `A-Z a-z 0-9 . _ ~ + / -`，`=` 只能作为末尾填充。可用 `openssl rand -base64 48 | tr -d '\n'` 分别生成。Gateway 角色必须填写管理 Token；Egress 角色应留空。Gateway 管理监听器默认绑定 `127.0.0.1`；公网 mTLS 节点通过 Gateway 公网监听器的受证书保护快照路径通信，不应把私有管理端口暴露到公网。
 
 ## Introduction
 
-OCI Mirror is a read-only OCI pull-through cache and fixed-origin proxy. Each 1Panel installation runs one Gateway or Egress role. Public inter-node communication defaults to mutually authenticated TLS.
+OCI Mirror is a read-only OCI pull-through cache and fixed-origin proxy. This store package is a single-Egress, Docker Hub preset; upstream multi-Egress, multi-registry, and custom fixed-origin deployments require direct configuration. Each 1Panel installation runs one Gateway or Egress role. Public inter-node communication defaults to mutually authenticated TLS.
 
 ## Features
 
@@ -82,7 +87,8 @@ OCI Mirror is a read-only OCI pull-through cache and fixed-origin proxy. Each 1P
 - Distributes node-scoped configuration snapshots from Gateway to Egress.
 - Supports IPv4-only, IPv6-only, and dual-stack Egress source pools.
 - Generates an idempotent node CA, Gateway identity, and bounded Egress certificate inventory.
-- Generates the mainland-China IPv4/IPv6 CIDR file from official APNIC delegated data when no file exists.
+- Renews generated leaf certificates before expiry without replacing their private keys.
+- Generates and periodically refreshes the mainland-China IPv4/IPv6 CIDR file from official APNIC delegated data.
 
 ## Security and Deployment Risks
 


### PR DESCRIPTION
## Summary
- make Gateway and Egress form requirements role-aware in the generated runtime configuration
- harden mTLS bootstrap, certificate renewal, path separation, and atomic configuration generation
- support IPv4/IPv6 source pools, allowlists, and managed APNIC CIDR refreshes
- document the single-Egress Docker Hub preset and deployment risks

## Verification
- `bash -n` and ShellCheck passed
- YAML and Docker Compose rendering passed
- `1panel-app-adapter validate-v2.sh --strict-store` passed (`fail=0`; only the intentionally omitted `source-evidence.json` warning)
- upstream Go tests, 1Panel test-target tests, fresh v2 install/import, mTLS Gateway/Egress runtime pair, restart, uninstall, and cleanup passed

Target branch: `localApps`.