### PR TITLE
fix: close inferred sidecar-only Renovate updates

### DIFF
--- a/.github/renovate-primary-services.json
+++ b/.github/renovate-primary-services.json
@@ -35,6 +35,9 @@
   "teldrive": [
     "teldrive"
   ],
+  "weblate": [
+    "weblate"
+  ],
   "wukongim": [
     "wukongim"
   ]

--- a/.github/scripts/renovate_sidecar_guard.py
+++ b/.github/scripts/renovate_sidecar_guard.py
@@ -84,6 +84,26 @@ def extract_app(path: str) -> str | None:
     return match.group(1) if match else None
 
 
+def resolve_primary_services(
+    app: str,
+    configured: list[str],
+    base_data: dict,
+    head_data: dict,
+) -> list[str]:
+    if configured:
+        return configured
+
+    base_services = base_data.get("services")
+    head_services = head_data.get("services")
+    if not isinstance(base_services, dict) or not isinstance(head_services, dict):
+        return []
+    if max(len(base_services), len(head_services)) <= 1:
+        return []
+    if app in base_services and app in head_services:
+        return [app]
+    return []
+
+
 def compare_compose(
     app: str,
     path: str,
@@ -185,13 +205,19 @@ def main() -> int:
             )
             continue
 
+        primary_services = resolve_primary_services(
+            app,
+            policy.get(app, []),
+            base_data,
+            head_data,
+        )
         decisions.append(
             compare_compose(
                 app=app,
                 path=resolved_head_path,
                 base_data=base_data,
                 head_data=head_data,
-                primary_services=policy.get(app, []),
+                primary_services=primary_services,
             )
         )
 

--- a/.github/scripts/test_renovate_sidecar_guard.py
+++ b/.github/scripts/test_renovate_sidecar_guard.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__).with_name("renovate_sidecar_guard.py")
+SPEC = importlib.util.spec_from_file_location("renovate_sidecar_guard", SCRIPT_PATH)
+GUARD = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+SPEC.loader.exec_module(GUARD)
+
+
+def compose(**images: str) -> dict:
+    return {"services": {name: {"image": image} for name, image in images.items()}}
+
+
+class ResolvePrimaryServicesTests(unittest.TestCase):
+    def test_infers_app_named_service_for_multi_service_app(self) -> None:
+        base = compose(cache="valkey:9.1.0", database="postgres:18", weblate="weblate:latest")
+        head = compose(cache="valkey:9.1.1", database="postgres:18", weblate="weblate:latest")
+
+        resolved = GUARD.resolve_primary_services("weblate", [], base, head)
+
+        self.assertEqual(resolved, ["weblate"])
+
+    def test_explicit_mapping_takes_precedence(self) -> None:
+        base = compose(api="example/api:1", sample="example/sample:1")
+        head = compose(api="example/api:2", sample="example/sample:1")
+
+        resolved = GUARD.resolve_primary_services("sample", ["api"], base, head)
+
+        self.assertEqual(resolved, ["api"])
+
+    def test_does_not_guess_when_no_service_matches_app_key(self) -> None:
+        base = compose(api="example/api:1", worker="example/worker:1")
+        head = compose(api="example/api:1", worker="example/worker:2")
+
+        resolved = GUARD.resolve_primary_services("sample", [], base, head)
+
+        self.assertEqual(resolved, [])
+
+    def test_does_not_infer_for_single_service_app(self) -> None:
+        base = compose(valkey="valkey:9.1.0")
+        head = compose(valkey="valkey:9.1.1")
+
+        resolved = GUARD.resolve_primary_services("valkey", [], base, head)
+
+        self.assertEqual(resolved, [])
+
+
+class InferredPrimaryDecisionTests(unittest.TestCase):
+    def test_closes_weblate_sidecar_only_update(self) -> None:
+        base = compose(cache="valkey:9.1.0", database="postgres:18", weblate="weblate:latest")
+        head = compose(cache="valkey:9.1.1", database="postgres:18", weblate="weblate:latest")
+        primary = GUARD.resolve_primary_services("weblate", [], base, head)
+
+        decision = GUARD.compare_compose("weblate", "apps/weblate/latest/docker-compose.yml", base, head, primary)
+
+        self.assertEqual(decision.outcome, "close")
+        self.assertEqual(decision.changed_services, ["cache"])
+
+    def test_allows_inferred_primary_update(self) -> None:
+        base = compose(cache="valkey:9.1.0", database="postgres:18", weblate="weblate:1")
+        head = compose(cache="valkey:9.1.1", database="postgres:18", weblate="weblate:2")
+        primary = GUARD.resolve_primary_services("weblate", [], base, head)
+
+        decision = GUARD.compare_compose("weblate", "apps/weblate/latest/docker-compose.yml", base, head, primary)
+
+        self.assertEqual(decision.outcome, "allow")
+
+    def test_allows_independent_single_service_app(self) -> None:
+        base = compose(server="valkey:9.1.0")
+        head = compose(server="valkey:9.1.1")
+
+        decision = GUARD.compare_compose("valkey", "apps/valkey/latest/docker-compose.yml", base, head, [])
+
+        self.assertEqual(decision.outcome, "allow")
+        self.assertEqual(decision.detail, "single-service compose")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/renovate-sidecar-guard.yml
+++ b/.github/workflows/renovate-sidecar-guard.yml
@@ -55,6 +55,9 @@ jobs:
               subprocess.check_call([sys.executable, "-m", "pip", "install", "--user", "pyyaml"])
           PY
 
+      - name: Test sidecar guard policy logic
+        run: python3 .github/scripts/test_renovate_sidecar_guard.py
+
       - name: Evaluate Renovate PR against primary-service policy
         id: guard
         env:


### PR DESCRIPTION
## 变更

- 在多服务应用未配置主服务映射时，仅当存在与 app key 精确同名的服务才将其推断为主服务
- 补充 `weblate -> weblate` 显式映射
- 将守卫单元测试接入 GitHub Actions

## 原因

PR #5063 只更新 Weblate 的 Valkey cache 辅助服务，但因缺少 Weblate 主服务映射被错误放行。修复后该 PR 判定为 `sidecar-only Renovate update detected (weblate:cache)`。

## 验证

- `python3 .github/scripts/test_renovate_sidecar_guard.py`
- `python3 -m py_compile ...`
- JSON/YAML 解析
- `actionlint .github/workflows/renovate-sidecar-guard.yml`
- 使用真实 PR #5063 回放，结果为 `decision: close`