### PR TITLE
feat(immich): add 3.0.3

### DIFF
--- a/apps/immich/3.0.3/.env.sample
+++ b/apps/immich/3.0.3/.env.sample
@@ -1,0 +1,10 @@
+
+CONTAINER_NAME="immich"
+PANEL_APP_PORT_HTTP="40194"
+PANEL_DB_NAME="immich"
+PANEL_DB_USER="postgres"
+PANEL_DB_USER_PASSWORD="immich_BfcHCZ"
+UPLOAD_LOCATION="./data/upload"
+CACHE_PATH="./data/cache"
+DB_PATH="./data/data"
+DB_STORAGE_TYPE="SSD"

--- a/apps/immich/3.0.3/data.yml
+++ b/apps/immich/3.0.3/data.yml
@@ -1,0 +1,140 @@
+additionalProperties:
+  formFields:
+    - default: 40194
+      edit: true
+      envKey: PANEL_APP_PORT_HTTP
+      labelEn: Port
+      labelZh: 端口
+      label:
+        en: 'Port'
+        zh: '端口'
+        zh-Hant: '埠'
+        ja: 'ポート'
+        ko: '포트'
+        ru: 'Порт'
+        ms: 'Port'
+        pt-br: 'Porta'
+      required: true
+      rule: paramPort
+      type: number
+    - default: ./data/upload
+      edit: true
+      envKey: UPLOAD_LOCATION
+      labelEn: Path to folder for uploading
+      labelZh: 上传用文件夹路径
+      label:
+        en: 'Path to folder for uploading'
+        zh: '上传用文件夹路径'
+        zh-Hant: '上傳用資料夾路徑'
+        ja: 'アップロード用フォルダーパス'
+        ko: '업로드 폴더 경로'
+        ru: 'Путь к папке для загрузки'
+        ms: 'Laluan folder untuk muat naik'
+        pt-br: 'Caminho da pasta para upload'
+      required: true
+      type: text
+    - default: ./data/cache
+      edit: true
+      envKey: CACHE_PATH
+      labelEn: Cache folder path
+      labelZh: 缓存文件夹路径
+      label:
+        en: 'Cache folder path'
+        zh: '缓存文件夹路径'
+        zh-Hant: '快取資料夾路徑'
+        ja: 'キャッシュフォルダーパス'
+        ko: '캐시 폴더 경로'
+        ru: 'Путь к папке кэша'
+        ms: 'Laluan folder cache'
+        pt-br: 'Caminho da pasta de cache'
+      required: true
+      type: text
+    - default: ./data/data
+      edit: true
+      envKey: DB_PATH
+      labelEn: Database folder path
+      labelZh: 数据库文件夹路径
+      label:
+        en: 'Database folder path'
+        zh: '数据库文件夹路径'
+        zh-Hant: '資料庫資料夾路徑'
+        ja: 'データベースフォルダーパス'
+        ko: '데이터베이스 폴더 경로'
+        ru: 'Путь к папке базы данных'
+        ms: 'Laluan folder pangkalan data'
+        pt-br: 'Caminho da pasta do banco de dados'
+      required: true
+      type: text
+    - default: SSD
+      edit: true
+      envKey: DB_STORAGE_TYPE
+      labelEn: Database storage type
+      labelZh: 数据库存储类型
+      label:
+        en: Database storage type
+        zh: 数据库存储类型
+        zh-Hant: 資料庫儲存類型
+        ja: データベースストレージ種別
+        ko: 데이터베이스 저장소 유형
+        ru: Тип хранилища базы данных
+        ms: Jenis storan pangkalan data
+        pt-br: Tipo de armazenamento do banco
+      required: true
+      type: select
+      values:
+        - label: SSD
+          value: SSD
+        - label: HDD
+          value: HDD
+    - default: immich
+      edit: true
+      envKey: PANEL_DB_NAME
+      labelEn: Database
+      labelZh: 数据库名
+      label:
+        en: 'Database'
+        zh: '数据库名'
+        zh-Hant: '數據庫名'
+        ja: 'データベース'
+        ko: '데이터베이스'
+        ru: 'База данных'
+        ms: 'Pangkalan Data'
+        pt-br: 'Banco de Dados'
+      required: true
+      rule: paramCommon
+      type: text
+    - default: postgres
+      edit: true
+      envKey: PANEL_DB_USER
+      labelEn: Postgres User
+      labelZh: Postgres 数据库用户
+      label:
+        en: 'Postgres User'
+        zh: 'Postgres 数据库用户'
+        zh-Hant: 'Postgres 資料庫使用者'
+        ja: 'Postgres ユーザー'
+        ko: 'Postgres 사용자'
+        ru: 'Пользователь Postgres'
+        ms: 'Pengguna Postgres'
+        pt-br: 'Usuário do Postgres'
+      required: true
+      rule: paramCommon
+      type: text
+    - default: immich
+      edit: true
+      envKey: PANEL_DB_USER_PASSWORD
+      labelEn: Postgres Password
+      labelZh: Postgres 数据库用户密码
+      label:
+        en: 'Postgres Password'
+        zh: 'Postgres 数据库用户密码'
+        zh-Hant: 'Postgres 資料庫使用者密碼'
+        ja: 'Postgres パスワード'
+        ko: 'Postgres 비밀번호'
+        ru: 'Пароль Postgres'
+        ms: 'Kata laluan Postgres'
+        pt-br: 'Senha do Postgres'
+      random: true
+      required: true
+      rule: paramComplexity
+      type: password

--- a/apps/immich/3.0.3/docker-compose.yml
+++ b/apps/immich/3.0.3/docker-compose.yml
@@ -1,0 +1,79 @@
+services:
+  immich-server:
+    container_name: ${CONTAINER_NAME}-server
+    restart: always
+    networks:
+      - 1panel-network
+    image: ghcr.io/immich-app/immich-server:v3.0.3
+    volumes:
+      - ${UPLOAD_LOCATION}:/data
+      - /etc/localtime:/etc/localtime:ro
+    environment:
+      - DB_PASSWORD=${PANEL_DB_USER_PASSWORD}
+      - DB_HOSTNAME=${CONTAINER_NAME}-postgres
+      - DB_USERNAME=${PANEL_DB_USER}
+      - DB_DATABASE_NAME=${PANEL_DB_NAME}
+      - REDIS_HOSTNAME=${CONTAINER_NAME}-redis
+    ports:
+      - ${PANEL_APP_PORT_HTTP}:2283
+    depends_on:
+      - immich-redis
+      - immich-database
+    healthcheck:
+      disable: false
+    labels:
+      createdBy: "Apps"
+
+  immich-machine-learning:
+    container_name: ${CONTAINER_NAME}-machine_learning
+    restart: always
+    networks:
+      - 1panel-network
+    image: ghcr.io/immich-app/immich-machine-learning:v3.0.3
+    volumes:
+      - ${CACHE_PATH}:/cache
+    environment:
+      - DB_PASSWORD=${PANEL_DB_USER_PASSWORD}
+      - DB_HOSTNAME=${CONTAINER_NAME}-postgres
+      - DB_USERNAME=${PANEL_DB_USER}
+      - DB_DATABASE_NAME=${PANEL_DB_NAME}
+      - REDIS_HOSTNAME=${CONTAINER_NAME}-redis
+    healthcheck:
+      disable: false
+    labels:
+      createdBy: "Apps"
+
+  immich-redis:
+    container_name: ${CONTAINER_NAME}-redis
+    restart: always
+    networks:
+      - 1panel-network
+    image: "docker.io/valkey/valkey:9@sha256:4963247afc4cd33c7d3b2d2816b9f7f8eeebab148d29056c2ca4d7cbc966f2d9"
+    healthcheck:
+      test: redis-cli ping || exit 1
+    labels:
+      createdBy: "Apps"
+
+  immich-database:
+    container_name: ${CONTAINER_NAME}-postgres
+    restart: always
+    networks:
+      - 1panel-network
+    image: "ghcr.io/immich-app/postgres:14-vectorchord0.4.3-pgvectors0.2.0@sha256:bcf63357191b76a916ae5eb93464d65c07511da41e3bf7a8416db519b40b1c23"
+    environment:
+      - POSTGRES_PASSWORD=${PANEL_DB_USER_PASSWORD}
+      - POSTGRES_USER=${PANEL_DB_USER}
+      - POSTGRES_DB=${PANEL_DB_NAME}
+      - POSTGRES_INITDB_ARGS=--data-checksums
+      - DB_STORAGE_TYPE=${DB_STORAGE_TYPE:-SSD}
+    volumes:
+      - ${DB_PATH}:/var/lib/postgresql/data
+    shm_size: 128mb
+    healthcheck:
+      disable: false
+    labels:
+      createdBy: "Apps"
+
+networks:
+  1panel-network:
+    external: true

--- a/apps/immich/3.0.3/scripts/init.sh
+++ b/apps/immich/3.0.3/scripts/init.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mkdir -p \
+  "${UPLOAD_LOCATION:-./data/upload}" \
+  "${CACHE_PATH:-./data/cache}" \
+  "${DB_PATH:-./data/data}"

--- a/apps/immich/3.0.3/scripts/uninstall.sh
+++ b/apps/immich/3.0.3/scripts/uninstall.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+docker compose down --volumes --remove-orphans

--- a/apps/immich/3.0.3/scripts/upgrade.sh
+++ b/apps/immich/3.0.3/scripts/upgrade.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ENV_FILE="${ENV_FILE:-./.env}"
+
+if [[ ! -f "$ENV_FILE" ]]; then
+  echo "$ENV_FILE not found; skipped Immich environment migration"
+  exit 0
+fi
+
+if grep -qE '^DB_STORAGE_TYPE=' "$ENV_FILE"; then
+  echo "DB_STORAGE_TYPE already exists"
+else
+  printf '%s\n' 'DB_STORAGE_TYPE=SSD' >> "$ENV_FILE"
+  echo "Added DB_STORAGE_TYPE"
+fi

--- a/apps/immich/README.md
+++ b/apps/immich/README.md
@@ -43,13 +43,15 @@ Immich is a high-performance open source photo and video management platform for
 
 升级或迁移前，请在 1Panel 中备份上述数据目录。
 
-从 `1.132.3` 升级到 `3.0.2` 前请特别注意：
+从 `1.132.3` 升级到 `3.x` 前请特别注意：
 
 - 必须先备份 `UPLOAD_LOCATION`，并通过 PostgreSQL 导出方式备份数据库；运行中的 `DB_PATH` 热拷贝不能作为可靠数据库备份。
 - 数据库镜像会从已弃用的 `pgvecto-rs` 切换到官方 VectorChord 兼容镜像。首次启动会执行扩展迁移和索引重建，大型图库可能需要较长时间。
 - 完成 VectorChord 迁移后不可降级到低于 `1.133.0` 的 Immich 版本。
 - v3 包含 API 等破坏性变更，依赖 Immich API 的第三方工具需要按官方 v3 migration guide 检查兼容性。
 - 移动客户端应在服务器升级前更新到与服务器主版本兼容的版本。
+
+从 `3.0.2` 升级到 `3.0.3` 不改变表单、持久化路径、Valkey 或 PostgreSQL 镜像。首次启动会自动执行数据库迁移；升级前仍需备份数据库和上传目录，并等待服务恢复健康后再执行其他操作。
 
 ## 配置项
 | 变量 | 说明 | 默认值 | 必填 |


### PR DESCRIPTION
## Summary

- add the official Immich server and machine-learning images for v3.0.3
- preserve the v3.0.2 form contract, persistence paths, lifecycle scripts, and pinned Valkey/PostgreSQL images
- extend the README upgrade guidance for v3 and the v3.0.2 to v3.0.3 database migration

## Verification

- `1panel-app-adapter` v1.2.9 `validate-v2.sh --strict-store`: pass (optional `source-evidence.json` warning only)
- Docker Compose render, env closure, shell syntax, and both official image manifests: pass
- `moelin/1panel:v2` fresh install: four services running, HTTP 200 before/after restart, uninstall and cleanup pass
- real 1Panel upgrade `3.0.2 -> 3.0.3`: migration `1782500000000-RestoreLivePhotoStillVisibility` succeeded, API reports 3.0.3, `immich-admin schema-check` reports no drift, restart/uninstall/cleanup pass
- appstore script tests: 48 passed

## Renovate decision

Immich remains outside the automerge whitelist because it is a coordinated multi-service application and this patch includes a database migration. Dashboard approval should remain required.

Related to #13.