### PR TITLE
Fix custom lifecycle paths for recent apps

### DIFF
--- a/apps/altus-linuxserver/5.8.1/scripts/init.sh
+++ b/apps/altus-linuxserver/5.8.1/scripts/init.sh
@@ -1,13 +1,44 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-paths=(
-  "${CONFIG_PATH:-./data/config}"
-)
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENV_FILE="${ENV_FILE:-$ROOT_DIR/.env}"
 
-mkdir -p "${paths[@]}"
-for path in "${paths[@]}"; do
-  case "$path" in
-    ./*|../*) chown -R 1000:1000 "$path" 2>/dev/null || true ;;
+read_env_value() {
+  local key="$1"
+  [[ -f "$ENV_FILE" ]] || return 0
+  local value
+  value="$(sed -n "s/^${key}=//p" "$ENV_FILE" | tail -n 1)"
+  case "$value" in
+    \"*\") value="${value#\"}"; value="${value%\"}" ;;
+    \'*\') value="${value#\'}"; value="${value%\'}" ;;
   esac
-done
+  printf '%s\n' "$value"
+}
+
+configured_value() {
+  local key="$1"
+  local default_value="$2"
+  local value
+  value="${!key:-}"
+  if [[ -z "$value" ]]; then
+    value="$(read_env_value "$key")"
+  fi
+  printf '%s\n' "${value:-$default_value}"
+}
+
+resolve_app_path() {
+  local raw="$1"
+  if [[ "$raw" = /* ]]; then
+    printf '%s\n' "$raw"
+  else
+    printf '%s\n' "$ROOT_DIR/${raw#./}"
+  fi
+}
+
+config_path_value="$(configured_value CONFIG_PATH ./data/config)"
+config_path="$(resolve_app_path "$config_path_value")"
+mkdir -p -- "$config_path"
+case "$config_path_value" in
+  ./*|../*) chown -R 1000:1000 -- "$config_path" 2>/dev/null || true ;;
+esac

--- a/apps/altus-linuxserver/5.8.1/scripts/upgrade.sh
+++ b/apps/altus-linuxserver/5.8.1/scripts/upgrade.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ENV_FILE="${ENV_FILE:-./.env}"
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENV_FILE="${ENV_FILE:-$ROOT_DIR/.env}"
 
 generate_secret() {
   if [[ -r /dev/urandom ]]; then
@@ -32,8 +33,8 @@ ensure_env_default() {
     current="$(sed -n -E "s/^${key}=//p" "$ENV_FILE" | tail -n 1)"
     current="${current%\"}"
     current="${current#\"}"
-    current="${current%'}"
-    current="${current#'}"
+    current="${current%\'}"
+    current="${current#\'}"
     if [[ "$fill_empty" == "true" && -z "$current" ]]; then
       sed -i -E "s|^${key}=.*|${key}=${value}|" "$ENV_FILE"
       echo "Updated empty $key"

--- a/apps/altus-linuxserver/latest/scripts/init.sh
+++ b/apps/altus-linuxserver/latest/scripts/init.sh
@@ -1,13 +1,44 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-paths=(
-  "${CONFIG_PATH:-./data/config}"
-)
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENV_FILE="${ENV_FILE:-$ROOT_DIR/.env}"
 
-mkdir -p "${paths[@]}"
-for path in "${paths[@]}"; do
-  case "$path" in
-    ./*|../*) chown -R 1000:1000 "$path" 2>/dev/null || true ;;
+read_env_value() {
+  local key="$1"
+  [[ -f "$ENV_FILE" ]] || return 0
+  local value
+  value="$(sed -n "s/^${key}=//p" "$ENV_FILE" | tail -n 1)"
+  case "$value" in
+    \"*\") value="${value#\"}"; value="${value%\"}" ;;
+    \'*\') value="${value#\'}"; value="${value%\'}" ;;
   esac
-done
+  printf '%s\n' "$value"
+}
+
+configured_value() {
+  local key="$1"
+  local default_value="$2"
+  local value
+  value="${!key:-}"
+  if [[ -z "$value" ]]; then
+    value="$(read_env_value "$key")"
+  fi
+  printf '%s\n' "${value:-$default_value}"
+}
+
+resolve_app_path() {
+  local raw="$1"
+  if [[ "$raw" = /* ]]; then
+    printf '%s\n' "$raw"
+  else
+    printf '%s\n' "$ROOT_DIR/${raw#./}"
+  fi
+}
+
+config_path_value="$(configured_value CONFIG_PATH ./data/config)"
+config_path="$(resolve_app_path "$config_path_value")"
+mkdir -p -- "$config_path"
+case "$config_path_value" in
+  ./*|../*) chown -R 1000:1000 -- "$config_path" 2>/dev/null || true ;;
+esac

--- a/apps/altus-linuxserver/latest/scripts/upgrade.sh
+++ b/apps/altus-linuxserver/latest/scripts/upgrade.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ENV_FILE="${ENV_FILE:-./.env}"
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENV_FILE="${ENV_FILE:-$ROOT_DIR/.env}"
 
 generate_secret() {
   if [[ -r /dev/urandom ]]; then
@@ -32,8 +33,8 @@ ensure_env_default() {
     current="$(sed -n -E "s/^${key}=//p" "$ENV_FILE" | tail -n 1)"
     current="${current%\"}"
     current="${current#\"}"
-    current="${current%'}"
-    current="${current#'}"
+    current="${current%\'}"
+    current="${current#\'}"
     if [[ "$fill_empty" == "true" && -z "$current" ]]; then
       sed -i -E "s|^${key}=.*|${key}=${value}|" "$ENV_FILE"
       echo "Updated empty $key"

--- a/apps/librechat/latest/scripts/init.sh
+++ b/apps/librechat/latest/scripts/init.sh
@@ -1,8 +1,43 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-DATA_DIR="${APP_DATA_DIR:-./data}"
-mkdir -p \
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENV_FILE="${ENV_FILE:-$ROOT_DIR/.env}"
+
+read_env_value() {
+  local key="$1"
+  [[ -f "$ENV_FILE" ]] || return 0
+  local value
+  value="$(sed -n "s/^${key}=//p" "$ENV_FILE" | tail -n 1)"
+  case "$value" in
+    \"*\") value="${value#\"}"; value="${value%\"}" ;;
+    \'*\') value="${value#\'}"; value="${value%\'}" ;;
+  esac
+  printf '%s\n' "$value"
+}
+
+configured_value() {
+  local key="$1"
+  local default_value="$2"
+  local value
+  value="${!key:-}"
+  if [[ -z "$value" ]]; then
+    value="$(read_env_value "$key")"
+  fi
+  printf '%s\n' "${value:-$default_value}"
+}
+
+resolve_app_path() {
+  local raw="$1"
+  if [[ "$raw" = /* ]]; then
+    printf '%s\n' "$raw"
+  else
+    printf '%s\n' "$ROOT_DIR/${raw#./}"
+  fi
+}
+
+DATA_DIR="$(resolve_app_path "$(configured_value APP_DATA_DIR ./data)")"
+mkdir -p -- \
   "${DATA_DIR}/images" \
   "${DATA_DIR}/uploads" \
   "${DATA_DIR}/logs" \
@@ -11,7 +46,7 @@ mkdir -p \
   "${DATA_DIR}/meilisearch" \
   "${DATA_DIR}/pgvector"
 
-chown -R 1000:1000 \
+chown -R 1000:1000 -- \
   "${DATA_DIR}/images" \
   "${DATA_DIR}/uploads" \
   "${DATA_DIR}/logs" \

--- a/apps/librechat/latest/scripts/upgrade.sh
+++ b/apps/librechat/latest/scripts/upgrade.sh
@@ -1,8 +1,43 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-DATA_DIR="${APP_DATA_DIR:-./data}"
-mkdir -p \
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENV_FILE="${ENV_FILE:-$ROOT_DIR/.env}"
+
+read_env_value() {
+  local key="$1"
+  [[ -f "$ENV_FILE" ]] || return 0
+  local value
+  value="$(sed -n "s/^${key}=//p" "$ENV_FILE" | tail -n 1)"
+  case "$value" in
+    \"*\") value="${value#\"}"; value="${value%\"}" ;;
+    \'*\') value="${value#\'}"; value="${value%\'}" ;;
+  esac
+  printf '%s\n' "$value"
+}
+
+configured_value() {
+  local key="$1"
+  local default_value="$2"
+  local value
+  value="${!key:-}"
+  if [[ -z "$value" ]]; then
+    value="$(read_env_value "$key")"
+  fi
+  printf '%s\n' "${value:-$default_value}"
+}
+
+resolve_app_path() {
+  local raw="$1"
+  if [[ "$raw" = /* ]]; then
+    printf '%s\n' "$raw"
+  else
+    printf '%s\n' "$ROOT_DIR/${raw#./}"
+  fi
+}
+
+DATA_DIR="$(resolve_app_path "$(configured_value APP_DATA_DIR ./data)")"
+mkdir -p -- \
   "${DATA_DIR}/images" \
   "${DATA_DIR}/uploads" \
   "${DATA_DIR}/logs" \
@@ -11,7 +46,7 @@ mkdir -p \
   "${DATA_DIR}/meilisearch" \
   "${DATA_DIR}/pgvector"
 
-chown -R 1000:1000 \
+chown -R 1000:1000 -- \
   "${DATA_DIR}/images" \
   "${DATA_DIR}/uploads" \
   "${DATA_DIR}/logs" \

--- a/apps/winegui-linuxserver/4.1.0/scripts/init.sh
+++ b/apps/winegui-linuxserver/4.1.0/scripts/init.sh
@@ -1,13 +1,44 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-paths=(
-  "${CONFIG_PATH:-./data/config}"
-)
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENV_FILE="${ENV_FILE:-$ROOT_DIR/.env}"
 
-mkdir -p "${paths[@]}"
-for path in "${paths[@]}"; do
-  case "$path" in
-    ./*|../*) chown -R 1000:1000 "$path" 2>/dev/null || true ;;
+read_env_value() {
+  local key="$1"
+  [[ -f "$ENV_FILE" ]] || return 0
+  local value
+  value="$(sed -n "s/^${key}=//p" "$ENV_FILE" | tail -n 1)"
+  case "$value" in
+    \"*\") value="${value#\"}"; value="${value%\"}" ;;
+    \'*\') value="${value#\'}"; value="${value%\'}" ;;
   esac
-done
+  printf '%s\n' "$value"
+}
+
+configured_value() {
+  local key="$1"
+  local default_value="$2"
+  local value
+  value="${!key:-}"
+  if [[ -z "$value" ]]; then
+    value="$(read_env_value "$key")"
+  fi
+  printf '%s\n' "${value:-$default_value}"
+}
+
+resolve_app_path() {
+  local raw="$1"
+  if [[ "$raw" = /* ]]; then
+    printf '%s\n' "$raw"
+  else
+    printf '%s\n' "$ROOT_DIR/${raw#./}"
+  fi
+}
+
+config_path_value="$(configured_value CONFIG_PATH ./data/config)"
+config_path="$(resolve_app_path "$config_path_value")"
+mkdir -p -- "$config_path"
+case "$config_path_value" in
+  ./*|../*) chown -R 1000:1000 -- "$config_path" 2>/dev/null || true ;;
+esac

--- a/apps/winegui-linuxserver/4.1.0/scripts/upgrade.sh
+++ b/apps/winegui-linuxserver/4.1.0/scripts/upgrade.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ENV_FILE="${ENV_FILE:-./.env}"
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENV_FILE="${ENV_FILE:-$ROOT_DIR/.env}"
 
 generate_secret() {
   if [[ -r /dev/urandom ]]; then
@@ -32,8 +33,8 @@ ensure_env_default() {
     current="$(sed -n -E "s/^${key}=//p" "$ENV_FILE" | tail -n 1)"
     current="${current%\"}"
     current="${current#\"}"
-    current="${current%'}"
-    current="${current#'}"
+    current="${current%\'}"
+    current="${current#\'}"
     if [[ "$fill_empty" == "true" && -z "$current" ]]; then
       sed -i -E "s|^${key}=.*|${key}=${value}|" "$ENV_FILE"
       echo "Updated empty $key"

--- a/apps/winegui-linuxserver/latest/scripts/init.sh
+++ b/apps/winegui-linuxserver/latest/scripts/init.sh
@@ -1,13 +1,44 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-paths=(
-  "${CONFIG_PATH:-./data/config}"
-)
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENV_FILE="${ENV_FILE:-$ROOT_DIR/.env}"
 
-mkdir -p "${paths[@]}"
-for path in "${paths[@]}"; do
-  case "$path" in
-    ./*|../*) chown -R 1000:1000 "$path" 2>/dev/null || true ;;
+read_env_value() {
+  local key="$1"
+  [[ -f "$ENV_FILE" ]] || return 0
+  local value
+  value="$(sed -n "s/^${key}=//p" "$ENV_FILE" | tail -n 1)"
+  case "$value" in
+    \"*\") value="${value#\"}"; value="${value%\"}" ;;
+    \'*\') value="${value#\'}"; value="${value%\'}" ;;
   esac
-done
+  printf '%s\n' "$value"
+}
+
+configured_value() {
+  local key="$1"
+  local default_value="$2"
+  local value
+  value="${!key:-}"
+  if [[ -z "$value" ]]; then
+    value="$(read_env_value "$key")"
+  fi
+  printf '%s\n' "${value:-$default_value}"
+}
+
+resolve_app_path() {
+  local raw="$1"
+  if [[ "$raw" = /* ]]; then
+    printf '%s\n' "$raw"
+  else
+    printf '%s\n' "$ROOT_DIR/${raw#./}"
+  fi
+}
+
+config_path_value="$(configured_value CONFIG_PATH ./data/config)"
+config_path="$(resolve_app_path "$config_path_value")"
+mkdir -p -- "$config_path"
+case "$config_path_value" in
+  ./*|../*) chown -R 1000:1000 -- "$config_path" 2>/dev/null || true ;;
+esac

--- a/apps/winegui-linuxserver/latest/scripts/upgrade.sh
+++ b/apps/winegui-linuxserver/latest/scripts/upgrade.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ENV_FILE="${ENV_FILE:-./.env}"
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENV_FILE="${ENV_FILE:-$ROOT_DIR/.env}"
 
 generate_secret() {
   if [[ -r /dev/urandom ]]; then
@@ -32,8 +33,8 @@ ensure_env_default() {
     current="$(sed -n -E "s/^${key}=//p" "$ENV_FILE" | tail -n 1)"
     current="${current%\"}"
     current="${current#\"}"
-    current="${current%'}"
-    current="${current#'}"
+    current="${current%\'}"
+    current="${current#\'}"
     if [[ "$fill_empty" == "true" && -z "$current" ]]; then
       sed -i -E "s|^${key}=.*|${key}=${value}|" "$ENV_FILE"
       echo "Updated empty $key"

--- a/apps/yaak-linuxserver/2026.5.0/scripts/init.sh
+++ b/apps/yaak-linuxserver/2026.5.0/scripts/init.sh
@@ -1,13 +1,44 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-paths=(
-  "${CONFIG_PATH:-./data/config}"
-)
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENV_FILE="${ENV_FILE:-$ROOT_DIR/.env}"
 
-mkdir -p "${paths[@]}"
-for path in "${paths[@]}"; do
-  case "$path" in
-    ./*|../*) chown -R 1000:1000 "$path" 2>/dev/null || true ;;
+read_env_value() {
+  local key="$1"
+  [[ -f "$ENV_FILE" ]] || return 0
+  local value
+  value="$(sed -n "s/^${key}=//p" "$ENV_FILE" | tail -n 1)"
+  case "$value" in
+    \"*\") value="${value#\"}"; value="${value%\"}" ;;
+    \'*\') value="${value#\'}"; value="${value%\'}" ;;
   esac
-done
+  printf '%s\n' "$value"
+}
+
+configured_value() {
+  local key="$1"
+  local default_value="$2"
+  local value
+  value="${!key:-}"
+  if [[ -z "$value" ]]; then
+    value="$(read_env_value "$key")"
+  fi
+  printf '%s\n' "${value:-$default_value}"
+}
+
+resolve_app_path() {
+  local raw="$1"
+  if [[ "$raw" = /* ]]; then
+    printf '%s\n' "$raw"
+  else
+    printf '%s\n' "$ROOT_DIR/${raw#./}"
+  fi
+}
+
+config_path_value="$(configured_value CONFIG_PATH ./data/config)"
+config_path="$(resolve_app_path "$config_path_value")"
+mkdir -p -- "$config_path"
+case "$config_path_value" in
+  ./*|../*) chown -R 1000:1000 -- "$config_path" 2>/dev/null || true ;;
+esac

--- a/apps/yaak-linuxserver/2026.5.0/scripts/upgrade.sh
+++ b/apps/yaak-linuxserver/2026.5.0/scripts/upgrade.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ENV_FILE="${ENV_FILE:-./.env}"
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENV_FILE="${ENV_FILE:-$ROOT_DIR/.env}"
 
 generate_secret() {
   if [[ -r /dev/urandom ]]; then
@@ -32,8 +33,8 @@ ensure_env_default() {
     current="$(sed -n -E "s/^${key}=//p" "$ENV_FILE" | tail -n 1)"
     current="${current%\"}"
     current="${current#\"}"
-    current="${current%'}"
-    current="${current#'}"
+    current="${current%\'}"
+    current="${current#\'}"
     if [[ "$fill_empty" == "true" && -z "$current" ]]; then
       sed -i -E "s|^${key}=.*|${key}=${value}|" "$ENV_FILE"
       echo "Updated empty $key"

--- a/apps/yaak-linuxserver/latest/scripts/init.sh
+++ b/apps/yaak-linuxserver/latest/scripts/init.sh
@@ -1,13 +1,44 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-paths=(
-  "${CONFIG_PATH:-./data/config}"
-)
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENV_FILE="${ENV_FILE:-$ROOT_DIR/.env}"
 
-mkdir -p "${paths[@]}"
-for path in "${paths[@]}"; do
-  case "$path" in
-    ./*|../*) chown -R 1000:1000 "$path" 2>/dev/null || true ;;
+read_env_value() {
+  local key="$1"
+  [[ -f "$ENV_FILE" ]] || return 0
+  local value
+  value="$(sed -n "s/^${key}=//p" "$ENV_FILE" | tail -n 1)"
+  case "$value" in
+    \"*\") value="${value#\"}"; value="${value%\"}" ;;
+    \'*\') value="${value#\'}"; value="${value%\'}" ;;
   esac
-done
+  printf '%s\n' "$value"
+}
+
+configured_value() {
+  local key="$1"
+  local default_value="$2"
+  local value
+  value="${!key:-}"
+  if [[ -z "$value" ]]; then
+    value="$(read_env_value "$key")"
+  fi
+  printf '%s\n' "${value:-$default_value}"
+}
+
+resolve_app_path() {
+  local raw="$1"
+  if [[ "$raw" = /* ]]; then
+    printf '%s\n' "$raw"
+  else
+    printf '%s\n' "$ROOT_DIR/${raw#./}"
+  fi
+}
+
+config_path_value="$(configured_value CONFIG_PATH ./data/config)"
+config_path="$(resolve_app_path "$config_path_value")"
+mkdir -p -- "$config_path"
+case "$config_path_value" in
+  ./*|../*) chown -R 1000:1000 -- "$config_path" 2>/dev/null || true ;;
+esac

--- a/apps/yaak-linuxserver/latest/scripts/upgrade.sh
+++ b/apps/yaak-linuxserver/latest/scripts/upgrade.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ENV_FILE="${ENV_FILE:-./.env}"
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENV_FILE="${ENV_FILE:-$ROOT_DIR/.env}"
 
 generate_secret() {
   if [[ -r /dev/urandom ]]; then
@@ -32,8 +33,8 @@ ensure_env_default() {
     current="$(sed -n -E "s/^${key}=//p" "$ENV_FILE" | tail -n 1)"
     current="${current%\"}"
     current="${current#\"}"
-    current="${current%'}"
-    current="${current#'}"
+    current="${current%\'}"
+    current="${current#\'}"
     if [[ "$fill_empty" == "true" && -z "$current" ]]; then
       sed -i -E "s|^${key}=.*|${key}=${value}|" "$ENV_FILE"
       echo "Updated empty $key"


### PR DESCRIPTION
## Summary

- make Altus, WineGUI, Yaak, and LibreChat lifecycle scripts read custom persistence paths from the installed `.env` without executing dotenv contents
- resolve relative paths from the application root and make LinuxServer upgrade migrations locate `.env` independently of the caller working directory
- keep numbered and `latest` packages aligned while preserving existing non-empty credentials during upgrades

## Validation

- `bash -n` and ShellCheck passed for all 14 changed scripts
- `1panel-app-adapter` runtime-script unit tests passed (4/4)
- strict-store and Docker Compose rendering passed for all 7 affected version directories
- Altus `5.8.1 -> latest` custom-path upgrade passed on `moelin/1panel:v2`, including HTTP, restart, uninstall, and cleanup
- WineGUI `4.1.0 -> latest` and Yaak `2026.5.0 -> latest` custom-path upgrades passed; out-of-install data was verified at UID/GID `1000:1000` before exact cleanup
- LibreChat `latest` custom-path fresh install passed with all 6 services running, HTTP 200 before/after restart, expected data-directory ownership, uninstall, and zero backend/Docker leftovers
- upgrade regression preserved quoted existing credentials and only filled quoted empty username/password values

No test used port `10086`. LibreChat remains outside Renovate automerge because it is a coordinated multi-service deployment.