### PR TITLE
docs(librespeed): document image security risk

### DIFF
--- a/apps/librespeed/README.md
+++ b/apps/librespeed/README.md
@@ -35,6 +35,14 @@
 - 首次启用前，请按安装表单填写域名、账号、密码、Token、数据目录等参数。
 - 如需对外开放访问，请同步检查防火墙、安全组和反向代理配置。
 
+## 安全风险
+- 本应用使用 LibreSpeed 官方镜像。该镜像包含完整的 Debian、PHP 和 Web 运行环境，漏洞扫描器可能报告继承自基础系统组件的 High 或 Critical 漏洞；升级可以减少已知漏洞，但不代表镜像不存在漏洞。
+- 部署前请重新扫描目标镜像，持续跟踪上游更新，并限制不必要的公网暴露。
+
+## Security Risks
+- This app uses the official LibreSpeed image. Its Debian, PHP, and web runtime may contain High or Critical vulnerabilities inherited from base-system packages; upgrading can reduce known findings but does not make the image vulnerability-free.
+- Re-scan the target image before deployment, track upstream releases, and avoid unnecessary public exposure.
+
 ## 参考资料
 - 官网: <https://librespeed.org/>
 - 文档: <https://github.com/librespeed/speedtest>


### PR DESCRIPTION
## 维护结论

这是 #5105 合并后的独立安全提示补充，不改动镜像或运行配置。

- LibreSpeed 6.1.0 -> 6.2.0 真实 1Panel v2 升级 smoke 已通过安装、升级、HTTP 200、重启、卸载和清理。
- Trivy 从 23 Critical / 457 High 降至 18 Critical / 92 High，没有新增 High/Critical 漏洞 ID。
- README 增加中英文、版本中立的镜像风险与部署建议。

## 变更范围

仅修改 `apps/librespeed/README.md`。