### PR TITLE
Harden Renovate blocked update handling

### DIFF
--- a/.github/renovate-docker.json
+++ b/.github/renovate-docker.json
@@ -446,7 +446,12 @@
         "apps/geekbench/5/**",
         "apps/headscale/0.23.0-alpha3/**",
         "apps/headscale/0.26.1/**",
-        "apps/mysql/5.5.62/**"
+        "apps/headscale/0.27.1/**",
+        "apps/headscale/0.28.0/**",
+        "apps/immich/1.122.3/**",
+        "apps/mysql/5.5.62/**",
+        "apps/safeline/7.3.1/**",
+        "apps/safeline/newnet-7.3.1/**"
       ],
       "enabled": false
     },
@@ -471,6 +476,21 @@
         "ghcr.io/clearflask/clearflask-server"
       ],
       "groupName": "ClearFlask application images"
+    },
+    {
+      "description": "Group SafeLine release images so all application components update together",
+      "matchFileNames": [
+        "apps/safeline/**/docker-compose.yml"
+      ],
+      "matchPackageNames": [
+        "chaitin/safeline-chaos",
+        "chaitin/safeline-detector",
+        "chaitin/safeline-fvm",
+        "chaitin/safeline-luigi",
+        "chaitin/safeline-mgt",
+        "chaitin/safeline-tengine"
+      ],
+      "groupName": "SafeLine application images"
     },
     {
       "description": "Disable bundled database-only updates for LinuxServer multi-service apps",
@@ -529,9 +549,20 @@
       ],
       "matchPackageNames": [
         "busybox",
+        "langgenius/dify-plugin-daemon",
         "nginx",
         "semitechnologies/weaviate",
         "ubuntu/squid"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "Keep uuWAF on the upstream-supported Percona 5.7 database line",
+      "matchFileNames": [
+        "apps/uuwaf/**/docker-compose.yml"
+      ],
+      "matchPackageNames": [
+        "percona/percona-server"
       ],
       "enabled": false
     },
@@ -542,6 +573,16 @@
       ],
       "matchPackageNames": [
         "nginx"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "Keep Langflow on the tested 1.10 security line pending baseline x86_64 support",
+      "matchFileNames": [
+        "apps/langflow/**/docker-compose.yml"
+      ],
+      "matchPackageNames": [
+        "langflowai/langflow"
       ],
       "enabled": false
     },

--- a/.github/renovate-primary-services.json
+++ b/.github/renovate-primary-services.json
@@ -12,14 +12,16 @@
     "worker",
     "worker_beat",
     "web",
-    "sandbox",
-    "plugin_daemon"
+    "sandbox"
   ],
   "diskover-linuxserver": [
     "diskover"
   ],
   "karakeep": [
     "karakeep"
+  ],
+  "immich": [
+    "immich-server"
   ],
   "librechat": [
     "librechat-api",
@@ -32,8 +34,14 @@
   "rocketchat": [
     "rocketchat"
   ],
+  "safeline": [
+    "safeline-mgt"
+  ],
   "teldrive": [
     "teldrive"
+  ],
+  "uuwaf": [
+    "uuwaf"
   ],
   "weblate": [
     "weblate"

--- a/.github/scripts/test_renovate_sidecar_guard.py
+++ b/.github/scripts/test_renovate_sidecar_guard.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import importlib.util
+import json
 import unittest
 from pathlib import Path
 
@@ -9,6 +10,10 @@ SPEC = importlib.util.spec_from_file_location("renovate_sidecar_guard", SCRIPT_P
 GUARD = importlib.util.module_from_spec(SPEC)
 assert SPEC and SPEC.loader
 SPEC.loader.exec_module(GUARD)
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+PRIMARY_SERVICES_PATH = REPOSITORY_ROOT / ".github" / "renovate-primary-services.json"
+RENOVATE_CONFIG_PATH = REPOSITORY_ROOT / ".github" / "renovate-docker.json"
 
 
 def compose(**images: str) -> dict:
@@ -77,6 +82,106 @@ class InferredPrimaryDecisionTests(unittest.TestCase):
 
         self.assertEqual(decision.outcome, "allow")
         self.assertEqual(decision.detail, "single-service compose")
+
+
+class RepositoryPolicyTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.primary_services = json.loads(PRIMARY_SERVICES_PATH.read_text(encoding="utf-8"))
+        cls.renovate_config = json.loads(RENOVATE_CONFIG_PATH.read_text(encoding="utf-8"))
+
+    def disabled_rule_exists(self, file_pattern: str, package_name: str | None = None) -> bool:
+        for rule in self.renovate_config["packageRules"]:
+            if rule.get("enabled") is not False:
+                continue
+            if file_pattern not in rule.get("matchFileNames", []):
+                continue
+            if package_name is None or package_name in rule.get("matchPackageNames", []):
+                return True
+        return False
+
+    def test_dify_plugin_daemon_is_not_a_primary_service(self) -> None:
+        self.assertNotIn("plugin_daemon", self.primary_services["dify"])
+        self.assertTrue(
+            self.disabled_rule_exists(
+                "apps/dify/**/docker-compose.yml",
+                "langgenius/dify-plugin-daemon",
+            )
+        )
+
+        base = compose(api="langgenius/dify-api:1.16.0", plugin_daemon="langgenius/dify-plugin-daemon:0.6.3-local")
+        head = compose(api="langgenius/dify-api:1.16.0", plugin_daemon="langgenius/dify-plugin-daemon:0.6.5-local")
+        decision = GUARD.compare_compose(
+            "dify",
+            "apps/dify/1.16.0/docker-compose.yml",
+            base,
+            head,
+            self.primary_services["dify"],
+        )
+
+        self.assertEqual(decision.outcome, "close")
+
+    def test_safeline_components_are_grouped_behind_management_service(self) -> None:
+        self.assertEqual(self.primary_services["safeline"], ["safeline-mgt"])
+        expected_images = {
+            "chaitin/safeline-chaos",
+            "chaitin/safeline-detector",
+            "chaitin/safeline-fvm",
+            "chaitin/safeline-luigi",
+            "chaitin/safeline-mgt",
+            "chaitin/safeline-tengine",
+        }
+        grouped_rules = [
+            rule
+            for rule in self.renovate_config["packageRules"]
+            if rule.get("groupName") == "SafeLine application images"
+        ]
+
+        self.assertEqual(len(grouped_rules), 1)
+        self.assertEqual(set(grouped_rules[0]["matchPackageNames"]), expected_images)
+        self.assertIn("apps/safeline/**/docker-compose.yml", grouped_rules[0]["matchFileNames"])
+
+    def test_blocked_historical_tracks_are_immutable(self) -> None:
+        expected_patterns = {
+            "apps/headscale/0.27.1/**",
+            "apps/headscale/0.28.0/**",
+            "apps/immich/1.122.3/**",
+            "apps/safeline/7.3.1/**",
+            "apps/safeline/newnet-7.3.1/**",
+        }
+
+        for pattern in expected_patterns:
+            with self.subTest(pattern=pattern):
+                self.assertTrue(self.disabled_rule_exists(pattern))
+
+    def test_uuwaf_database_is_not_updated_independently(self) -> None:
+        self.assertEqual(self.primary_services["uuwaf"], ["uuwaf"])
+        self.assertTrue(
+            self.disabled_rule_exists(
+                "apps/uuwaf/**/docker-compose.yml",
+                "percona/percona-server",
+            )
+        )
+
+        base = compose(uuwaf="uusec/nanqiang:v6.8.0", wafdb="percona/percona-server:5.7.44")
+        head = compose(uuwaf="uusec/nanqiang:v6.8.0", wafdb="percona/percona-server:8.4.2")
+        decision = GUARD.compare_compose(
+            "uuwaf",
+            "apps/uuwaf/6.8.0/docker-compose.yml",
+            base,
+            head,
+            self.primary_services["uuwaf"],
+        )
+
+        self.assertEqual(decision.outcome, "close")
+
+    def test_langflow_updates_require_manual_compatibility_review(self) -> None:
+        self.assertTrue(
+            self.disabled_rule_exists(
+                "apps/langflow/**/docker-compose.yml",
+                "langflowai/langflow",
+            )
+        )
 
 
 if __name__ == "__main__":

--- a/apps/immich/README.md
+++ b/apps/immich/README.md
@@ -24,6 +24,7 @@ Immich is a high-performance open source photo and video management platform for
 
 ## 部署说明
 - 本应用使用 Docker Compose 在 1Panel 中部署。
+- `1.122.3` 和 `release` 是为旧安装保留的社区镜像版本，使用 `altran1502/immich-*`，不是 Immich 官方镜像；新安装应优先选择使用 `ghcr.io/immich-app/*` 官方镜像的 `3.x` 固定版本。
 - 应用分类：媒体。
 - 支持架构：amd64。
 - 可选版本以应用商店页面为准。


### PR DESCRIPTION
## Summary

- freeze superseded Headscale, Immich, and SafeLine version directories so Renovate cannot rewrite historical rollback/upgrade tracks in place
- block Dify plugin-daemon-only, uuWAF Percona-only, and Langflow compatibility-blocked updates
- group all six SafeLine application images and define explicit primary services for Immich, SafeLine, and uuWAF
- label retained Immich `altran1502` versions as community images and recommend official 3.x packages for new installs
- add repository-policy regressions to the Renovate sidecar guard tests

## Blocked dashboard disposition

- Dify #5032: not recreated. Official Dify `1.16.0` Compose still pins `langgenius/dify-plugin-daemon:0.6.3-local`; the daemon must move with an upstream Dify release.
- Immich #2853 / #2854: superseded by coordinated official-image update #5065 (`3.0.3`). The old community-image `1.122.3` track remains immutable.
- SafeLine #2971-#2976 / #3426-#3431: superseded by coordinated six-image update #5069 (`9.3.10`). Future component updates share one Renovate group and still require dashboard approval/manual review.
- Headscale #4586: superseded by staged upgrade #5097 (`0.27.1 -> 0.28.0 -> 0.29.2`). Bridge versions remain immutable.
- Langflow #5100: superseded by tested security update #5166 (`1.10.3`); Renovate stays disabled until baseline x86_64 compatibility is restored upstream.
- uuWAF / Percona #2848: not recreated. Current supported uuWAF `6.8.0` deployment still requires Percona 5.7; an in-place 5.7 to 8.4 database major upgrade has no upstream migration evidence.

No application Compose, form, environment, data path, or lifecycle script changes are included in this PR.

## Verification

- RED before policy changes: 7 assertion failures and 2 missing-policy errors
- GREEN after policy changes: all 12 sidecar guard tests passed
- full `.github/scripts` suite: 53 tests passed
- official `ghcr.io/renovatebot/renovate:43` `renovate-config-validator --strict`: passed
- JSON parsing and `git diff --check`: passed
- task-owned validator and Langflow test containers: removed

Renovate 43 documents that matching updates with one `groupName` share a branch/PR and that `matchFileNames` applies glob/regex rules to dependency package files:

- https://github.com/renovatebot/renovate/blob/43.280.4/docs/usage/configuration-options.md#groupname
- https://github.com/renovatebot/renovate/blob/43.280.4/docs/usage/configuration-options.md#packageRulesmatchfilenames

Related to #13.
