### PR TITLE
Correct Immich legacy image attribution

### DIFF
--- a/apps/immich/README.md
+++ b/apps/immich/README.md
@@ -24,7 +24,7 @@ Immich is a high-performance open source photo and video management platform for
 
 ## 部署说明
 - 本应用使用 Docker Compose 在 1Panel 中部署。
-- `1.122.3` 和 `release` 是为旧安装保留的社区镜像版本，使用 `altran1502/immich-*`，不是 Immich 官方镜像；新安装应优先选择使用 `ghcr.io/immich-app/*` 官方镜像的 `3.x` 固定版本。
+- `1.122.3` 和 `release` 使用 Immich 创始人 Alex Tran 的旧 Docker Hub 发布命名空间 `altran1502/immich-*`，不是普通社区重构镜像；当前官方 Compose 已使用 `ghcr.io/immich-app/*`，新安装应优先选择对应的 `3.x` 固定版本。
 - 应用分类：媒体。
 - 支持架构：amd64。
 - 可选版本以应用商店页面为准。


### PR DESCRIPTION
## Summary

Correct the README wording introduced in #5167: `altran1502/immich-*` is the legacy Docker Hub publishing namespace used by Immich founder Alex Tran, not an unrelated community rebuild.

The current recommendation remains unchanged: new installations should use fixed `3.x` packages based on the official `ghcr.io/immich-app/*` Compose path.

## Evidence

- The appstore's initial Immich package from January 2024 already used `altran1502/immich-*` and linked Alex Tran's GitHub Sponsors and `altran1502` donation identity in the imported upstream README.
- Docker Hub `v1.122.3` tags were published by `altran1502` within minutes of the Immich `v1.122.3` release and provide amd64/arm64 manifests.
- Immich's official `v1.122.3` Compose used `ghcr.io/immich-app/*`; there is no repository evidence that GHCR images were unable to run.
- Current official `v3.0.3` server and machine-learning manifests provide amd64/arm64, and #5065 recorded a successful real 1Panel fresh install and `3.0.2 -> 3.0.3` upgrade.

Documentation-only correction; `git diff --check` passed. No Compose, form, environment, data, or lifecycle changes.
