### PR TITLE
docs: improve README layout and navigation

### DIFF
--- a/README-en.md
+++ b/README-en.md
@@ -1,25 +1,29 @@
-[中文](https://github.com/okxlin/appstore/blob/localApps/README.md) | English
+<h1 align="center">1Panel Third-Party App Store</h1>
 
-# 1Panel Third-Party App Store
+<p align="center">
+  Docker app configurations adapted for the <code>1Panel</code> app store <code>2.0</code>. After import, apps can be installed from the 1Panel local app store or run directly with <code>docker-compose</code> from each app version directory.
+</p>
 
-Docker app configurations adapted for the `1Panel` app store `2.0`. After import, apps can be installed from the 1Panel local app store or run directly with `docker-compose` from each app version directory.
+<p align="center">
+  <img src="docs/afdian-logo.png" alt="Docker Apps project banner" width="640">
+</p>
+
+<p align="center">
+  <a href="README.md"><img src="https://img.shields.io/badge/%E7%AE%80%E4%BD%93%E4%B8%AD%E6%96%87-D9D9D9?style=flat-square" alt="阅读简体中文版"></a>
+  <a href="README-en.md"><img src="https://img.shields.io/badge/English-2875B6?style=flat-square" alt="English (current language)"></a>
+</p>
 
 ## Support
 
-[**Support via AFDIAN**](https://afdian.com/a/dockerapps)
+<p align="center">
+  <a href="https://afdian.com/a/dockerapps"><strong>Support this project on AFDIAN</strong></a><br><br>
+  <strong>WeChat Reward Code</strong><br>
+  <img src="docs/wechat-reward.webp" alt="WeChat reward code" width="200">
+</p>
 
-[![Support via AFDIAN](https://github.com/okxlin/appstore/raw/localApps/docs/afdian-logo.png)](https://afdian.com/a/dockerapps)
+<details>
+<summary><strong>Table of Contents</strong></summary>
 
-**WeChat Reward Code**
-
-<img src="docs/wechat-reward.webp" alt="WeChat reward code" width="240">
-
-***
-
-## Table of Contents
-
-- [Support](#support)
-- [Table of Contents](#table-of-contents)
 - [Disclaimer](#disclaimer)
   - [1. Image Container Adaptation](#1-image-container-adaptation)
   - [2. Compliance with Laws](#2-compliance-with-laws)
@@ -34,18 +38,22 @@ Docker app configurations adapted for the `1Panel` app store `2.0`. After import
 - [4. Remarks](#4-remarks)
 - [5. App Overview](#5-app-overview)
 
+</details>
 
 ***
 
 ## Disclaimer
 
 ### 1. Image Container Adaptation
+
 This project specifically adapts to the `1Panel` app store for original `docker` image container operations. We do not make any explicit or implicit warranties or statements regarding the validity of any original images, and we are not responsible for any effects caused by using applications from this repository. Users undertake the risks associated with using this project on their own.
 
 ### 2. Compliance with Laws
+
 When using this repository, users must comply with the laws and regulations of their respective countries and regions. Certain applications may be restricted by specific national laws, and users need to understand and comply with relevant legal requirements. This repository is not responsible for any consequences arising from the user's violation of laws and regulations.
 
 ### 3. Acceptance of Disclaimer
+
 By importing and using the applications in this repository, the user signifies that they have read, understood, and accepted all the terms and conditions of this disclaimer.
 
 Please note that this disclaimer applies only to the use of this repository and does not encompass other third-party applications or services. We are not responsible for the accuracy, completeness, reliability, or legality of third-party content linked to this repository.
@@ -53,10 +61,10 @@ Please note that this disclaimer applies only to the use of this repository and 
 Before using this repository, please ensure that you have read, understood, and accepted all the terms and conditions of this disclaimer.
 
 ***
-## 1. Introduction
-These are some configurations of docker applications adapted for the `1Panel` store version 2.0.
 
-This repository keeps app directories, metadata, form variables, and compose files recognizable by 1Panel so users can avoid repeated manual deployment work.
+## 1. Introduction
+
+This repository organizes app directories, metadata, form variables, and Docker Compose files according to the 1Panel v2 app specification. The goal is to make apps installable after import with less manual deployment and repeated configuration.
 
 ## 2. Contributing Apps
 
@@ -81,9 +89,9 @@ The examples below use official GitHub URLs. Replace them according to your prox
 
 ### 3.2 Getting Apps via Git Command
 
-In the `Shell Script` task type in the `1Panel` scheduled tasks, add and execute the following command, or run it in a terminal:
+Create a `Shell Script` scheduled task in 1Panel and run the following commands, or execute them directly in a terminal:
 
-```shell
+```bash
 git clone -b localApps https://github.com/okxlin/appstore /opt/1panel/resource/apps/local/appstore-localApps
 
 cp -rf /opt/1panel/resource/apps/local/appstore-localApps/apps/* /opt/1panel/resource/apps/local/
@@ -91,13 +99,13 @@ cp -rf /opt/1panel/resource/apps/local/appstore-localApps/apps/* /opt/1panel/res
 rm -rf /opt/1panel/resource/apps/local/appstore-localApps
 ```
 
-Then refresh the local applications in the app store.
+When the commands finish, refresh the local apps in the app store.
 
 ### 3.3 Getting Apps via Compressed Package
 
-In the `Shell Script` task type in the `1Panel` scheduled tasks, add and execute the following command, or run it in a terminal:
+Create a `Shell Script` scheduled task in 1Panel and run the following commands, or execute them directly in a terminal:
 
-```shell
+```bash
 wget -P /opt/1panel/resource/apps/local https://github.com/okxlin/appstore/archive/refs/heads/localApps.zip
 
 unzip -o -d /opt/1panel/resource/apps/local/ /opt/1panel/resource/apps/local/localApps.zip
@@ -109,19 +117,16 @@ rm -rf /opt/1panel/resource/apps/local/appstore-localApps
 rm -rf /opt/1panel/resource/apps/local/localApps.zip
 ```
 
-Then refresh the local applications in the app store.
+When the commands finish, refresh the local apps in the app store.
 
 ## 4. Remarks
 
-**If an application is not displayed in the local app list, it means it has not been fully adapted for operation in the app store panel.**
+> [!NOTE]
+> Apps that do not appear in the local app list have not been fully adapted for panel operations, but they can usually still be run from a terminal.
 
-**However, it can still be run directly in the terminal.**
+For example, to run `rustdesk`:
 
-> Most applications in this repository support running directly with `docker-compose up`
-
-Taking `rustdesk` as an example:
-
-```shell
+```bash
 # Enter the latest version directory of rustdesk
 cd /opt/1panel/resource/apps/local/rustdesk/versions/latest/
 
@@ -136,7 +141,6 @@ docker-compose up -d
 
 # View the necessary key for connecting
 cat ./data/hbbs/id_ed25519.pub
-
 ```
 
 ## 5. App Overview

--- a/README.md
+++ b/README.md
@@ -1,24 +1,29 @@
-中文 | [English](https://github.com/okxlin/appstore/blob/localApps/README-en.md)
+<h1 align="center">1Panel 第三方应用商店</h1>
 
-# 1Panel 第三方应用商店
+<p align="center">
+  适配 <code>1Panel</code> 应用商店 <code>2.0</code> 的 Docker 应用配置合集。导入后可在 1Panel 本地应用商店中安装，也可以进入应用版本目录后用 <code>docker-compose</code> 直接运行。
+</p>
 
-适配 `1Panel` 应用商店 `2.0` 的 Docker 应用配置合集。导入后可在 1Panel 本地应用商店中安装，也可以进入应用版本目录后用 `docker-compose` 直接运行。
+<p align="center">
+  <img src="docs/afdian-logo.png" alt="Docker Apps 项目标识" width="640">
+</p>
+
+<p align="center">
+  <a href="README.md"><img src="https://img.shields.io/badge/%E7%AE%80%E4%BD%93%E4%B8%AD%E6%96%87-2875B6?style=flat-square" alt="简体中文（当前语言）"></a>
+  <a href="README-en.md"><img src="https://img.shields.io/badge/English-D9D9D9?style=flat-square" alt="Read in English"></a>
+</p>
 
 ## 支持项目
 
-[**爱发电赞助：用爱发电**](https://afdian.com/a/dockerapps)
+<p align="center">
+  <a href="https://afdian.com/a/dockerapps"><strong>爱发电赞助：用爱发电</strong></a><br><br>
+  <strong>微信赞赏</strong><br>
+  <img src="docs/wechat-reward.webp" alt="微信赞赏码" width="200">
+</p>
 
-[![爱发电赞助：用爱发电](https://github.com/okxlin/appstore/raw/localApps/docs/afdian-logo.png)](https://afdian.com/a/dockerapps)
+<details>
+<summary><strong>目录</strong></summary>
 
-**微信赞赏**
-
-<img src="docs/wechat-reward.webp" alt="微信赞赏码" width="240">
-
-***
-## 目录
-
-- [支持项目](#支持项目)
-- [目录](#目录)
 - [免责声明](#免责声明)
   - [1. 镜像容器适配](#1-镜像容器适配)
   - [2. 法律遵守](#2-法律遵守)
@@ -33,18 +38,22 @@
 - [4. 备注](#4-备注)
 - [5. 应用一览图](#5-应用一览图)
 
+</details>
 
 ***
 
 ## 免责声明
 
 ### 1. 镜像容器适配
+
 本项目仅针对原`docker`镜像容器运行进行针对`1Panel`应用商店的适配。我们不对任何原始镜像的有效性做出任何明示或暗示的保证或声明，并且不对使用本仓库应用所造成的任何影响负责。用户在使用本项目时应自行承担风险。
 
 ### 2. 法律遵守
+
 用户在使用本仓库时必须遵守所在国家与地区的法律法规。某些应用可能受到特定国家法律的限制，用户需自行了解并遵守相关法律要求。本仓库不对用户违反法律法规所产生的任何后果负责。
 
 ### 3. 免责声明接受
+
 用户在导入本仓库并使用其中的应用时，即表示用户已经阅读、理解并同意接受本免责声明的所有条款和条件。
 
 请注意，本免责声明仅针对本仓库的使用情况，并不包括其他第三方应用或服务。对于与本仓库链接的第三方内容，我们不对其准确性、完整性、可靠性或合法性负责。
@@ -52,10 +61,10 @@
 在使用本仓库之前，请确保已经阅读、理解并接受了本免责声明的所有条款和条件。
 
 ***
-## 1. 简介
-这是一些适配 `1Panel` 应用商店 `2.0` 的 Docker 应用配置。
 
-本仓库尽量保持应用目录、元数据、表单变量和 compose 配置可被 1Panel 直接识别，降低手动部署和重复配置成本。
+## 1. 简介
+
+本仓库按 1Panel v2 应用规范组织应用目录、元数据、表单变量和 Docker Compose 配置，尽量做到导入后即可安装，减少手动部署和重复配置。
 
 ## 2. 贡献应用
 
@@ -80,8 +89,9 @@ GitHub 代理镜像的可用性变化很快，本 README 不再维护固定加�
 
 ### 3.2 使用 git 命令获取应用
 
-`1Panel`计划任务类型`Shell 脚本`的计划任务框里，添加并执行以下命令，或者终端运行以下命令，
-```shell
+在 1Panel 中新建类型为 `Shell 脚本` 的计划任务，粘贴并执行以下命令；也可以直接在终端执行：
+
+```bash
 git clone -b localApps https://github.com/okxlin/appstore /opt/1panel/resource/apps/local/appstore-localApps
 
 cp -rf /opt/1panel/resource/apps/local/appstore-localApps/apps/* /opt/1panel/resource/apps/local/
@@ -89,12 +99,13 @@ cp -rf /opt/1panel/resource/apps/local/appstore-localApps/apps/* /opt/1panel/res
 rm -rf /opt/1panel/resource/apps/local/appstore-localApps
 ```
 
-然后应用商店刷新本地应用即可。
+执行完成后，在应用商店中刷新本地应用。
 
 ### 3.3 使用压缩包方式获取应用
 
-`1Panel`计划任务类型`Shell 脚本`的计划任务框里，添加并执行以下命令，或者终端运行以下命令，
-```shell
+在 1Panel 中新建类型为 `Shell 脚本` 的计划任务，粘贴并执行以下命令；也可以直接在终端执行：
+
+```bash
 wget -P /opt/1panel/resource/apps/local https://github.com/okxlin/appstore/archive/refs/heads/localApps.zip
 
 unzip -o -d /opt/1panel/resource/apps/local/ /opt/1panel/resource/apps/local/localApps.zip
@@ -106,20 +117,16 @@ rm -rf /opt/1panel/resource/apps/local/appstore-localApps
 rm -rf /opt/1panel/resource/apps/local/localApps.zip
 ```
 
-然后应用商店刷新本地应用即可。
-
+执行完成后，在应用商店中刷新本地应用。
 
 ## 4. 备注
 
-**未显示在本地应用列表里的，表示未完全适配应用商店面板操作**
+> [!NOTE]
+> 未显示在本地应用列表中的应用，表示尚未完全适配面板操作，但通常仍可通过终端运行。
 
-**但是支持直接终端运行。**
+以 `rustdesk` 为例：
 
-> 本仓库应用基本支持直接 `docker-compose up` 运行
-
-以`rustdesk`为例
-
-```shell
+```bash
 # 进入 rustdesk 的最新版本目录
 cd /opt/1panel/resource/apps/local/rustdesk/versions/latest/
 
@@ -134,7 +141,6 @@ docker-compose up -d
 
 # 查看连接所需密钥
 cat ./data/hbbs/id_ed25519.pub
-
 ```
 
 ## 5. 应用一览图


### PR DESCRIPTION
## Summary

- center the bilingual README headers and project banner
- add compact language navigation badges
- separate the project banner from donation links and keep the WeChat reward code near the top
- collapse the table of contents and clarify usage copy while preserving the original disclaimer wording

## Validation

- rendered both files through the GitHub Markdown API
- verified all referenced external links return HTTP 200
- confirmed the branch contains one commit and changes only README.md and README-en.md
- scanned the final diff for secret patterns