### PR TITLE
Allow asciinema server latest image updates

### DIFF
--- a/apps/asciinema-server/README.md
+++ b/apps/asciinema-server/README.md
@@ -30,7 +30,7 @@ asciinema server 是 asciinema 生态的服务端组件，用于托管、浏览�
 
 ## 镜像安全说明
 
-固定的 asciinema server `20260626` 镜像在交付时报告 `0 Critical / 5 High`。这些发现位于 Alpine OpenSSL 和 Expat 系统库，均已有修复包但最新稳定镜像尚未重建。PostgreSQL 镜像报告的 `1 Critical / 14 High` 全部来自仅用于启动时降权的 `gosu` Go 二进制；数据库不对外提供 TLS/HTTP/邮件处理面。更换任一镜像 digest 时必须重新扫描和复核。
+本次审计使用的 asciinema server `20260626` 镜像快照报告 `0 Critical / 5 High`。这些发现位于 Alpine OpenSSL 和 Expat 系统库，均已有修复包但该快照尚未重建。PostgreSQL 镜像快照报告的 `1 Critical / 14 High` 全部来自仅用于启动时降权的 `gosu` Go 二进制；数据库不对外提供 TLS/HTTP/邮件处理面。固定版本目录保留已审计 digest；`latest` 目录使用不带 digest 的移动标签，标签解析到新镜像后必须重新扫描和复核。
 
 ## Introduction
 

--- a/apps/asciinema-server/latest/docker-compose.yml
+++ b/apps/asciinema-server/latest/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   asciinema-server:
-    image: "ghcr.io/asciinema/asciinema-server:latest@sha256:0474b2186be46b23f5e16dbd4319727dbb68f27a303705fbe632821bf524b313"
+    image: "ghcr.io/asciinema/asciinema-server:latest"
     container_name: ${CONTAINER_NAME}
     restart: unless-stopped
     depends_on:
@@ -46,7 +46,7 @@ services:
       createdBy: "Apps"
 
   asciinema-postgres:
-    image: "postgres:17-alpine@sha256:742f40ea20b9ff2ff31db5458d127452988a2164df9e17441e191f3b72252193"
+    image: "postgres:17-alpine"
     container_name: ${CONTAINER_NAME}-postgres
     restart: unless-stopped
     user: "70:70"


### PR DESCRIPTION
## Summary

- Remove 2 digest pin(s) from images in the `latest` directory while retaining every image tag.
- This restores tag-based updates for Watchtower and similar tooling; fixed-version directories are unchanged.

## Verification

- Registry comparison found the moving tag still resolves to the former pinned digest.
- Strict store validation with full strict i18n passed for all packaged versions: 20260626, latest.
- Docker Compose parsing passed for the submitted `latest` file.

Baseline: `9457ae896d598a9d8a7ec0c8a692af1d0138104e`