### PR TITLE
Allow Blocky latest image updates

### DIFF
--- a/apps/blocky/latest/docker-compose.yml
+++ b/apps/blocky/latest/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   blocky:
-    image: "spx01/blocky:latest@sha256:595136fb127f4c952b621113e668c09acdcf15ac054d96ee6d4c51a76c35f5fd"
+    image: "spx01/blocky:latest"
     container_name: ${CONTAINER_NAME}
     restart: unless-stopped
     networks:


### PR DESCRIPTION
## Summary

- Remove 1 digest pin(s) from images in the `latest` directory while retaining every image tag.
- This restores tag-based updates for Watchtower and similar tooling; fixed-version directories are unchanged.

## Verification

- Registry comparison found the moving tag still resolves to the former pinned digest.
- Strict store validation with full strict i18n passed for all packaged versions: 0.34.0, latest.
- Docker Compose parsing passed for the submitted `latest` file.

Baseline: `9457ae896d598a9d8a7ec0c8a692af1d0138104e`