### PR TITLE
Allow Codex2API latest image updates

### DIFF
--- a/apps/codex2api/README.md
+++ b/apps/codex2api/README.md
@@ -40,8 +40,8 @@ Codex2API is a Codex account-pool gateway that exposes OpenAI and Anthropic comp
 
 - 仅应在可信环境中部署，并建议通过反向代理启用 HTTPS、限制管理后台来源并配置防火墙访问控制。不要在 HTTP 明文连接中上传真实 Token。
 - 本应用强制设置 `CODEX_ALLOW_ANONYMOUS=false`。下游 API Key 仍需在管理后台创建，不能只依赖网络边界。
-- 固定版本镜像来自上游作者的 GHCR，OCI source、revision 和版本标签与 `v2.5.8` 源码提交一致。
-- 截至 2026-07-21，上游 `2.5.8` 镜像基于已结束支持的 Alpine 3.19。Trivy 在运行文件系统中报告 `musl` 和 `musl-utils` 的 `CVE-2026-40200`（High），镜像安装的是 `1.2.4_git20230717-r5`，修复版本为 `r6`。应用二进制以 `CGO_ENABLED=0` 构建，但镜像内基础工具仍受影响；对该风险敏感时应等待上游发布更新镜像后再部署。
+- 固定版本 `2.6.1` 的镜像来自上游作者的 GHCR，并保留已验证 digest。
+- `latest` 目录直接跟随上游移动标签，不固定 digest，以便 Watchtower 等工具拉取更新。标签解析到新镜像后必须重新执行镜像扫描、管理登录、API Key、重启与数据持久化验证。
 - 上游 README 声明使用 MIT License，但仓库没有独立的 `LICENSE` 文件，OCI license 标签也为空。部署和再分发前请自行确认许可证条件。
 
 ## 参考资料

--- a/apps/codex2api/README_en.md
+++ b/apps/codex2api/README_en.md
@@ -22,8 +22,8 @@ Codex2API is a Codex account-pool gateway that exposes OpenAI and Anthropic comp
 
 - Deploy only in a trusted environment. Use HTTPS through a reverse proxy, restrict access to the admin dashboard, and configure firewall controls. Never upload real tokens over plaintext HTTP.
 - This package forces `CODEX_ALLOW_ANONYMOUS=false`. Downstream API keys must still be created in the admin dashboard and should not be replaced by network controls alone.
-- The fixed image comes from the upstream author's GHCR namespace. Its OCI source, revision, and version labels match the `v2.5.8` source commit.
-- As of 2026-07-21, upstream image `2.5.8` uses end-of-life Alpine 3.19. Trivy reports `CVE-2026-40200` (High) in runtime `musl` and `musl-utils`: the image has `1.2.4_git20230717-r5`, while `r6` contains the fix. The application binary was built with `CGO_ENABLED=0`, but base-image utilities remain affected. Wait for a rebuilt upstream image before deployment if this risk is unacceptable.
+- The fixed `2.6.1` image comes from the upstream author's GHCR namespace and retains its verified digest.
+- The `latest` package follows the upstream moving tag without a digest so tools such as Watchtower can pull updates. A newly resolved image requires fresh image scanning and renewed verification of admin login, API-key use, restart, and data persistence.
 - The upstream README declares the MIT License, but the repository has no standalone `LICENSE` file and the OCI license label is empty. Confirm the applicable license terms before deployment or redistribution.
 
 ## References

--- a/apps/codex2api/latest/docker-compose.yml
+++ b/apps/codex2api/latest/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   codex2api:
-    image: "ghcr.io/james-6-23/codex2api:latest@sha256:4d610d4f01f462757cd4bde4cffc0029202192acf3fe5bb36897f1a487b57906"
+    image: "ghcr.io/james-6-23/codex2api:latest"
     container_name: ${CONTAINER_NAME}
     restart: always
     security_opt:


### PR DESCRIPTION
## Summary

- Remove 1 digest pin(s) from images in the `latest` directory while retaining every image tag.
- This restores tag-based updates for Watchtower and similar tooling; fixed-version directories are unchanged.

## Verification

- The current moving tag advanced from the former digest and passed real 1Panel v2 install and readiness checks.
- The default user workflow persisted across an application restart performed through 1Panel, followed by successful uninstall and task-resource cleanup.
- Strict store validation with full strict i18n passed for all packaged versions: 2.6.1, latest.
- Docker Compose parsing passed for the submitted `latest` file.

Baseline: `9457ae896d598a9d8a7ec0c8a692af1d0138104e`