### PR TITLE
Allow DooTask latest image updates

### DIFF
--- a/apps/dootask/README.md
+++ b/apps/dootask/README.md
@@ -31,8 +31,8 @@ DooTask is an open source team collaboration and task management platform with p
 ## 部署说明
 
 - 本应用基于上游仓库 `kuaifan/dootask` 的官方发布线 `v1.8.64` 适配。
-- PHP 运行镜像使用维护者发布的 `kuaifan/php:swoole-8.4@sha256:4f69395d5b8a72256338aa6042a6caaaf598bb5cc0b4ab30a84ef9cc4c5e61e2`。
-- Nginx 使用官方镜像 `nginx:1.27-alpine@sha256:65645c7bb6a0661892a8b03b89d0743208a18dd2f3f17a54ef4b76fb8e2f2a10`。
+- PHP 运行镜像使用维护者发布的 `kuaifan/php:swoole-8.4`，Nginx 使用官方镜像 `nginx:1.31-alpine`。
+- 固定版本目录保留已测试 digest；`latest` 目录不固定 digest，允许 Watchtower 等工具拉取同一标签的新镜像。镜像更新后应重新验证启动、迁移和默认工作流。
 - 上游官方 compose 还包含 `mariadb`、`redis` 和 `appstore` sidecar；其中 `appstore` sidecar 依赖 `privileged` 与 Docker Socket，但它不是主站启动必需组件，因此本适配明确移除。
 - 数据库与 Redis 表单都按 1Panel 服务实例/服务名接入设计：MySQL 使用数据库服务选择器，Redis 使用 `key: redis` 的服务选择器；运行时仍保持 `PANEL_DB_HOST` / `REDIS_HOST` 等既有环境变量，避免升级时破坏老用户现有 `.env`。
 - 上游 `v1.8.64` 有少量历史 migration 与现代 MySQL 8 严格模式不兼容，包括 `TEXT default ''` 和一条 `distinct + chunk` 查询排序问题；本适配会在首次解包源码后仅对这些已确认 migration 做幂等兼容修补，再继续官方迁移流程。
@@ -84,7 +84,7 @@ DooTask is an open source team collaboration and task management platform with p
 ## 风险与升级说明
 
 - 这是一个上游源码首启下载型包，而不是纯镜像即开即用包；首次安装耗时明显高于普通应用。
-- 当前包固定到 `v1.8.64` 发布线，`latest` 目录也同样固定到这一版本。
+- 当前包的应用源码固定到 `v1.8.64` 发布线，`latest` 目录也使用这一版源码；运行镜像标签可独立更新。
 - 为兼容现代 MySQL 8 安装，入口脚本会对上游少量已确认的历史 migration 做一次性本地修补；这不会自动升级到其他上游版本。
 - Redis 服务选择器这次只修正了安装表单元数据，未改动实际运行时 envKey，因此老用户已有 `REDIS_HOST` / `REDIS_PORT` / `PANEL_REDIS_ROOT_PASSWORD` 配置仍可直接沿用。
 - 自动 in-place 源码升级暂未放开；`upgrade.sh` 只输出明确提醒，不会做破坏性迁移。

--- a/apps/dootask/latest/docker-compose.yml
+++ b/apps/dootask/latest/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   dootask:
-    image: "kuaifan/php:swoole-8.4@sha256:4f69395d5b8a72256338aa6042a6caaaf598bb5cc0b4ab30a84ef9cc4c5e61e2"
+    image: "kuaifan/php:swoole-8.4"
     container_name: ${CONTAINER_NAME}
     restart: always
     entrypoint:
@@ -44,7 +44,7 @@ services:
       createdBy: "Apps"
 
   nginx:
-    image: "nginx:1.31-alpine@sha256:54f2a904c251d5a34adf545a72d32515a15e08418dae0266e23be2e18c66fefa"
+    image: "nginx:1.31-alpine"
     container_name: ${CONTAINER_NAME}-nginx
     restart: always
     depends_on:


### PR DESCRIPTION
## Summary

- Remove 2 digest pin(s) from images in the `latest` directory while retaining every image tag.
- This restores tag-based updates for Watchtower and similar tooling; fixed-version directories are unchanged.

## Verification

- The current moving tag advanced from the former digest and passed real 1Panel v2 install and readiness checks.
- The default user workflow persisted across an application restart performed through 1Panel, followed by successful uninstall and task-resource cleanup.
- Strict store validation with full strict i18n passed for all packaged versions: 1.8.64, latest.
- Docker Compose parsing passed for the submitted `latest` file.

Baseline: `9457ae896d598a9d8a7ec0c8a692af1d0138104e`