### PR TITLE
Allow Flagsmith latest image updates

### DIFF
--- a/apps/flagsmith/latest/docker-compose.yml
+++ b/apps/flagsmith/latest/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   flagsmith-migrate:
-    image: "flagsmith/flagsmith:latest@sha256:7b1de96620270210650c52bb082d70c86100ccb62a21f40a5ad782c05ef7278a"
+    image: "flagsmith/flagsmith:latest"
     container_name: ${CONTAINER_NAME}-migrate
     restart: unless-stopped
     entrypoint: ["/bin/sh", "-c"]
@@ -34,7 +34,7 @@ services:
       createdBy: "Apps"
 
   flagsmith:
-    image: "flagsmith/flagsmith:latest@sha256:7b1de96620270210650c52bb082d70c86100ccb62a21f40a5ad782c05ef7278a"
+    image: "flagsmith/flagsmith:latest"
     container_name: ${CONTAINER_NAME}
     restart: unless-stopped
     command: ["serve"]
@@ -71,7 +71,7 @@ services:
       createdBy: "Apps"
 
   flagsmith-task-processor:
-    image: "flagsmith/flagsmith:latest@sha256:7b1de96620270210650c52bb082d70c86100ccb62a21f40a5ad782c05ef7278a"
+    image: "flagsmith/flagsmith:latest"
     container_name: ${CONTAINER_NAME}-task-processor
     restart: unless-stopped
     command: ["run-task-processor"]


### PR DESCRIPTION
## Summary

- Remove 3 digest pin(s) from images in the `latest` directory while retaining every image tag.
- This restores tag-based updates for Watchtower and similar tooling; fixed-version directories are unchanged.

## Verification

- The current moving tag advanced from the former digest and passed real 1Panel v2 install and readiness checks.
- The default user workflow persisted across an application restart performed through 1Panel, followed by successful uninstall and task-resource cleanup.
- Strict store validation with full strict i18n passed for all packaged versions: 2.260.0, latest.
- Docker Compose parsing passed for the submitted `latest` file.

Baseline: `9457ae896d598a9d8a7ec0c8a692af1d0138104e`