### PR TITLE
Allow Fusion latest image updates

### DIFF
--- a/apps/fusion/README.md
+++ b/apps/fusion/README.md
@@ -22,8 +22,8 @@ Fusion 是一款轻量级自托管 RSS/Atom 阅读器，支持未读状态、书
 
 - 本应用默认禁止抓取私网和本机地址的订阅源。确需读取内网订阅时，应先评估 SSRF 与网络边界，不要直接修改默认模板。
 - 官方镜像为兼容旧数据而暂时以 root 启动；本应用面向新安装强制使用镜像内的 `100:101` 用户，并使用只读根文件系统、丢弃全部 Linux capabilities、启用 `no-new-privileges`。登录、创建分组和重启持久性已在该约束下验证。
-- 固定版和当前 `latest` 的新鲜 amd64/arm64 扫描均包含基础系统及 Go 依赖漏洞。唯一 Critical ID `CVE-2026-31789` 只影响 32 位平台，不适用于本应用支持的 amd64/arm64。镜像中的 OpenSSL、zlib 和 iconv 不被静态链接的 Fusion 主程序调用；默认健康检查也只访问本机明文 HTTP。
-- `x/net/html` 用于订阅解析和 URL 重写，最终文章内容仍由浏览器端 DOMPurify 白名单净化后才渲染。QUIC、SSH 和 JWE 漏洞路径不属于默认 HTTP/password 部署流程。这些是默认路径的可达性例外，不代表镜像没有漏洞；镜像摘要、入口或配置发生变化后必须重新审计。
+- 固定版和本次审计的 `latest` 镜像快照在 amd64/arm64 扫描中均包含基础系统及 Go 依赖漏洞。唯一 Critical ID `CVE-2026-31789` 只影响 32 位平台，不适用于本应用支持的 amd64/arm64。镜像中的 OpenSSL、zlib 和 iconv 不被静态链接的 Fusion 主程序调用；默认健康检查也只访问本机明文 HTTP。
+- `x/net/html` 用于订阅解析和 URL 重写，最终文章内容仍由浏览器端 DOMPurify 白名单净化后才渲染。QUIC、SSH 和 JWE 漏洞路径不属于默认 HTTP/password 部署流程。这些是默认路径的可达性例外，不代表镜像没有漏洞；移动 `latest` 标签解析到新镜像、入口或配置发生变化后必须重新审计。
 
 ## Introduction
 
@@ -44,12 +44,12 @@ Fusion is a lightweight self-hosted RSS/Atom reader with unread tracking, bookma
 
 ## Security Note
 
-Fresh amd64 and arm64 scans of the fixed release and current `latest` image contain base-system and Go dependency findings. The only Critical ID, `CVE-2026-31789`, requires a 32-bit platform and does not apply to the supported architectures. Fusion is a static Go binary and does not call the image's OpenSSL, zlib, or iconv tooling in the default path. Feed HTML is ultimately sanitized with a DOMPurify allowlist before browser rendering; QUIC, SSH, and JWE vulnerable paths are not used by the default HTTP/password deployment. These are reachability exceptions for the audited defaults, not claims that the images are vulnerability-free.
+Fresh amd64 and arm64 scans of the fixed release and the audited `latest` image snapshot contain base-system and Go dependency findings. The only Critical ID, `CVE-2026-31789`, requires a 32-bit platform and does not apply to the supported architectures. Fusion is a static Go binary and does not call the image's OpenSSL, zlib, or iconv tooling in the default path. Feed HTML is ultimately sanitized with a DOMPurify allowlist before browser rendering; QUIC, SSH, and JWE vulnerable paths are not used by the default HTTP/password deployment. These are reachability exceptions for the audited snapshot, not claims that later images are vulnerability-free; reassess when the moving `latest` tag resolves to a new image.
 
 ## References
 
 - Project: <https://github.com/0x2E/fusion>
-- Stable release: <https://github.com/0x2E/fusion/releases/tag/v1.2.0>
-- Dockerfile: <https://github.com/0x2E/fusion/blob/v1.2.0/Dockerfile>
-- Configuration: <https://github.com/0x2E/fusion/blob/v1.2.0/.env.example>
-- License: <https://github.com/0x2E/fusion/blob/v1.2.0/LICENSE> (MIT)
+- Stable release: <https://github.com/0x2E/fusion/releases/tag/v1.2.1>
+- Dockerfile: <https://github.com/0x2E/fusion/blob/v1.2.1/Dockerfile>
+- Configuration: <https://github.com/0x2E/fusion/blob/v1.2.1/.env.example>
+- License: <https://github.com/0x2E/fusion/blob/v1.2.1/LICENSE> (MIT)

--- a/apps/fusion/data.yml
+++ b/apps/fusion/data.yml
@@ -25,7 +25,7 @@ additionalProperties:
   recommend: 0
   website: https://github.com/0x2E/fusion
   github: https://github.com/0x2E/fusion
-  document: https://github.com/0x2E/fusion/blob/v1.2.0/README.md
+  document: https://github.com/0x2E/fusion/blob/v1.2.1/README.md
   architectures:
     - amd64
     - arm64

--- a/apps/fusion/latest/docker-compose.yml
+++ b/apps/fusion/latest/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   fusion:
-    image: ghcr.io/0x2e/fusion:latest@sha256:4fa7eead46976f2090cfbb7e60f29946eccf0a5979c1fc168d7a9d89648a6a9b
+    image: ghcr.io/0x2e/fusion:latest
     container_name: ${CONTAINER_NAME}
     restart: unless-stopped
     user: "100:101"


### PR DESCRIPTION
## Summary

- Remove 1 digest pin(s) from images in the `latest` directory while retaining every image tag.
- This restores tag-based updates for Watchtower and similar tooling; fixed-version directories are unchanged.

## Verification

- Registry comparison found the moving tag still resolves to the former pinned digest.
- Strict store validation with full strict i18n passed for all packaged versions: 1.2.1, latest.
- Docker Compose parsing passed for the submitted `latest` file.

Baseline: `9457ae896d598a9d8a7ec0c8a692af1d0138104e`