### PR TITLE
Allow GoDoxy latest image updates

### DIFF
--- a/apps/godoxy/README.md
+++ b/apps/godoxy/README.md
@@ -50,7 +50,7 @@ Only containers explicitly carrying GoDoxy proxy labels are discovered by defaul
 
 ## Image Security Note
 
-The pinned v0.30.0 GoDoxy image reports three High findings in its bundled Moby client library. The affected daemon-side authorization, archive upload, and copy implementations are not used by the read-only socket policy. The pinned socket-proxy image reports one Go `os.Root` High; that binary contains no `os.Root` call site. These findings should be reassessed when either pinned image digest changes.
+The image snapshots retained by the fixed `0.30.1` package report three High findings in GoDoxy's bundled Moby client library and one Go `os.Root` High in the socket proxy. The affected daemon-side authorization, archive upload, and copy implementations are not used by the read-only socket policy, and the socket-proxy binary contains no `os.Root` call site. The `latest` package follows unpinned moving tags; reassess these findings whenever either tag resolves to a new image.
 
 ## Data
 

--- a/apps/godoxy/latest/docker-compose.yml
+++ b/apps/godoxy/latest/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   socket-proxy:
-    image: "ghcr.io/yusing/socket-proxy:latest@sha256:d2f20bd06728c9465a01725f1782f591c2cd5ade79027654fcf8b436a0fd0ca6"
+    image: "ghcr.io/yusing/socket-proxy:latest"
     container_name: ${CONTAINER_NAME}-socket-proxy
     restart: unless-stopped
     environment:
@@ -25,7 +25,7 @@ services:
       createdBy: "Apps"
 
   godoxy:
-    image: "ghcr.io/yusing/godoxy:latest@sha256:7e6f0dd72c042c096fa375978ebdfb8251e9a519d91bd93c9fbc2973b5f29127"
+    image: "ghcr.io/yusing/godoxy:latest"
     container_name: ${CONTAINER_NAME}
     restart: unless-stopped
     depends_on:


### PR DESCRIPTION
## Summary

- Remove 2 digest pin(s) from images in the `latest` directory while retaining every image tag.
- This restores tag-based updates for Watchtower and similar tooling; fixed-version directories are unchanged.

## Verification

- Registry comparison found the moving tag still resolves to the former pinned digest.
- Strict store validation with full strict i18n passed for all packaged versions: 0.30.1, latest.
- Docker Compose parsing passed for the submitted `latest` file.

Baseline: `9457ae896d598a9d8a7ec0c8a692af1d0138104e`