### PR TITLE
Allow Kaneo latest image updates

### DIFF
--- a/apps/kaneo/README.md
+++ b/apps/kaneo/README.md
@@ -71,5 +71,5 @@ tasks, labels, comments, time tracking, live updates, and integrations.
 ## References
 
 - Source: <https://github.com/usekaneo/kaneo>
-- Release: <https://github.com/usekaneo/kaneo/releases/tag/v2.9.9>
+- Fixed release: <https://github.com/usekaneo/kaneo/releases/tag/v2.9.10>
 - Self-hosting: <https://github.com/usekaneo/kaneo#self-hosting>

--- a/apps/kaneo/latest/docker-compose.yml
+++ b/apps/kaneo/latest/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   kaneo-postgres:
-    image: postgres:16-alpine@sha256:57c72fd2a128e416c7fcc499958864df5301e940bca0a56f58fddf30ffc07777
+    image: postgres:16-alpine
     container_name: ${CONTAINER_NAME}-postgres
     restart: unless-stopped
     user: "70:70"
@@ -30,7 +30,7 @@ services:
       createdBy: "Apps"
 
   kaneo:
-    image: ghcr.io/usekaneo/kaneo:latest@sha256:f1940688542264de86a4360ce6654c83c2a457eb23ccfe533f231909d4297943
+    image: ghcr.io/usekaneo/kaneo:latest
     container_name: ${CONTAINER_NAME}
     restart: unless-stopped
     user: "1001:1001"


### PR DESCRIPTION
## Summary

- Remove 2 digest pin(s) from images in the `latest` directory while retaining every image tag.
- This restores tag-based updates for Watchtower and similar tooling; fixed-version directories are unchanged.

## Verification

- The current moving tag advanced from the former digest and passed real 1Panel v2 install and readiness checks.
- The default user workflow persisted across an application restart performed through 1Panel, followed by successful uninstall and task-resource cleanup.
- Strict store validation with full strict i18n passed for all packaged versions: 2.9.10, latest.
- Docker Compose parsing passed for the submitted `latest` file.

Baseline: `9457ae896d598a9d8a7ec0c8a692af1d0138104e`