### PR TITLE
Allow LittleLink Server latest image updates

### DIFF
--- a/apps/littlelink-server/README.md
+++ b/apps/littlelink-server/README.md
@@ -28,7 +28,7 @@ LittleLink Server is a lightweight self-hosted personal link page. Environment v
 
 ## Deployment And Security
 
-- The package pins the official `latest` image to the reviewed OCI digest because upstream does not publish versioned releases.
+- The package follows the official unpinned `latest` tag because upstream does not publish versioned releases. This supports Watchtower-style updates, but each newly resolved image requires renewed review.
 - The container runs as the image's non-root `node` user, drops all Linux capabilities, prevents privilege escalation, and uses a read-only root filesystem.
 - Values are rendered into a public page. Do not place passwords, private tokens, or non-public URLs in profile fields.
 - External avatar and link URLs are loaded by visitors' browsers. Use trusted HTTPS destinations and terminate public access through the 1Panel reverse proxy.

--- a/apps/littlelink-server/latest/docker-compose.yml
+++ b/apps/littlelink-server/latest/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   littlelink-server:
-    image: "ghcr.io/timothystewart6/littlelink-server:latest@sha256:b0921c1403331dcaf7ba93b7528f03d58ae8fc132b23297bd9cb46166f005aa0"
+    image: "ghcr.io/timothystewart6/littlelink-server:latest"
     container_name: ${CONTAINER_NAME}
     restart: always
     networks:


### PR DESCRIPTION
## Summary

- Remove 1 digest pin(s) from images in the `latest` directory while retaining every image tag.
- This restores tag-based updates for Watchtower and similar tooling; fixed-version directories are unchanged.

## Verification

- Registry comparison found the moving tag still resolves to the former pinned digest.
- Strict store validation with full strict i18n passed for all packaged versions: latest.
- Docker Compose parsing passed for the submitted `latest` file.

Baseline: `9457ae896d598a9d8a7ec0c8a692af1d0138104e`