### PR TITLE
Format SilverBullet i18n labels

### DIFF
--- a/apps/silverbullet/2.10.0/data.yml
+++ b/apps/silverbullet/2.10.0/data.yml
@@ -5,7 +5,15 @@ additionalProperties:
       envKey: PANEL_APP_PORT_HTTP
       labelEn: Web Port
       labelZh: Web 端口
-      label: {en: Web Port, zh: Web 端口, zh-Hant: Web 連接埠, ja: Web ポート, ko: Web 포트, ru: Веб-порт, ms: Port Web, pt-br: Porta Web}
+      label:
+        en: Web Port
+        zh: Web 端口
+        zh-Hant: Web 連接埠
+        ja: Web ポート
+        ko: Web 포트
+        ru: Веб-порт
+        ms: Port Web
+        pt-br: Porta Web
       required: true
       rule: paramPort
       type: number
@@ -14,7 +22,15 @@ additionalProperties:
       envKey: SB_USERNAME
       labelEn: Login Username
       labelZh: 登录用户名
-      label: {en: Login Username, zh: 登录用户名, zh-Hant: 登入使用者名稱, ja: ログインユーザー名, ko: 로그인 사용자 이름, ru: Имя пользователя, ms: Nama Pengguna Log Masuk, pt-br: Nome de usuario}
+      label:
+        en: Login Username
+        zh: 登录用户名
+        zh-Hant: 登入使用者名稱
+        ja: ログインユーザー名
+        ko: 로그인 사용자 이름
+        ru: Имя пользователя
+        ms: Nama Pengguna Log Masuk
+        pt-br: Nome de usuario
       required: true
       type: text
     - default: ""
@@ -22,7 +38,15 @@ additionalProperties:
       envKey: SB_PASSWORD
       labelEn: Login Password
       labelZh: 登录密码
-      label: {en: Login Password, zh: 登录密码, zh-Hant: 登入密碼, ja: ログインパスワード, ko: 로그인 비밀번호, ru: Пароль, ms: Kata Laluan Log Masuk, pt-br: Senha de acesso}
+      label:
+        en: Login Password
+        zh: 登录密码
+        zh-Hant: 登入密碼
+        ja: ログインパスワード
+        ko: 로그인 비밀번호
+        ru: Пароль
+        ms: Kata Laluan Log Masuk
+        pt-br: Senha de acesso
       random: true
       required: true
       type: password
@@ -31,6 +55,14 @@ additionalProperties:
       envKey: SPACE_DIR
       labelEn: Space Directory
       labelZh: Space 数据目录
-      label: {en: Space Directory, zh: Space 数据目录, zh-Hant: Space 資料目錄, ja: Space ディレクトリ, ko: Space 데이터 디렉터리, ru: Каталог Space, ms: Direktori Space, pt-br: Diretorio do Space}
+      label:
+        en: Space Directory
+        zh: Space 数据目录
+        zh-Hant: Space 資料目錄
+        ja: Space ディレクトリ
+        ko: Space 데이터 디렉터리
+        ru: Каталог Space
+        ms: Direktori Space
+        pt-br: Diretorio do Space
       required: true
       type: text

--- a/apps/silverbullet/latest/data.yml
+++ b/apps/silverbullet/latest/data.yml
@@ -5,7 +5,15 @@ additionalProperties:
       envKey: PANEL_APP_PORT_HTTP
       labelEn: Web Port
       labelZh: Web 端口
-      label: {en: Web Port, zh: Web 端口, zh-Hant: Web 連接埠, ja: Web ポート, ko: Web 포트, ru: Веб-порт, ms: Port Web, pt-br: Porta Web}
+      label:
+        en: Web Port
+        zh: Web 端口
+        zh-Hant: Web 連接埠
+        ja: Web ポート
+        ko: Web 포트
+        ru: Веб-порт
+        ms: Port Web
+        pt-br: Porta Web
       required: true
       rule: paramPort
       type: number
@@ -14,7 +22,15 @@ additionalProperties:
       envKey: SB_USERNAME
       labelEn: Login Username
       labelZh: 登录用户名
-      label: {en: Login Username, zh: 登录用户名, zh-Hant: 登入使用者名稱, ja: ログインユーザー名, ko: 로그인 사용자 이름, ru: Имя пользователя, ms: Nama Pengguna Log Masuk, pt-br: Nome de usuario}
+      label:
+        en: Login Username
+        zh: 登录用户名
+        zh-Hant: 登入使用者名稱
+        ja: ログインユーザー名
+        ko: 로그인 사용자 이름
+        ru: Имя пользователя
+        ms: Nama Pengguna Log Masuk
+        pt-br: Nome de usuario
       required: true
       type: text
     - default: ""
@@ -22,7 +38,15 @@ additionalProperties:
       envKey: SB_PASSWORD
       labelEn: Login Password
       labelZh: 登录密码
-      label: {en: Login Password, zh: 登录密码, zh-Hant: 登入密碼, ja: ログインパスワード, ko: 로그인 비밀번호, ru: Пароль, ms: Kata Laluan Log Masuk, pt-br: Senha de acesso}
+      label:
+        en: Login Password
+        zh: 登录密码
+        zh-Hant: 登入密碼
+        ja: ログインパスワード
+        ko: 로그인 비밀번호
+        ru: Пароль
+        ms: Kata Laluan Log Masuk
+        pt-br: Senha de acesso
       random: true
       required: true
       type: password
@@ -31,6 +55,14 @@ additionalProperties:
       envKey: SPACE_DIR
       labelEn: Space Directory
       labelZh: Space 数据目录
-      label: {en: Space Directory, zh: Space 数据目录, zh-Hant: Space 資料目錄, ja: Space ディレクトリ, ko: Space 데이터 디렉터리, ru: Каталог Space, ms: Direktori Space, pt-br: Diretorio do Space}
+      label:
+        en: Space Directory
+        zh: Space 数据目录
+        zh-Hant: Space 資料目錄
+        ja: Space ディレクトリ
+        ko: Space 데이터 디렉터리
+        ru: Каталог Space
+        ms: Direktori Space
+        pt-br: Diretorio do Space
       required: true
       type: text


### PR DESCRIPTION
## Summary

- Expand 8 inline multilingual label maps into readable YAML blocks.

## Verification

- Parsed YAML is structurally identical before and after formatting.
- Strict store validation with full strict i18n passed for all packaged versions: 2.10.0, latest.

Baseline: `9457ae896d598a9d8a7ec0c8a692af1d0138104e`