### PR TITLE
Allow Yamtrack latest image updates

### DIFF
--- a/apps/yamtrack/latest/docker-compose.yml
+++ b/apps/yamtrack/latest/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   yamtrack:
-    image: "ghcr.io/fuzzygrim/yamtrack:latest@sha256:00acf008bca8171226063bc0f8f08ef7ffe24a10bcebf8676cce335ce312c307"
+    image: "ghcr.io/fuzzygrim/yamtrack:latest"
     container_name: ${CONTAINER_NAME}
     restart: unless-stopped
     depends_on:
@@ -34,7 +34,7 @@ services:
       createdBy: "Apps"
 
   yamtrack-redis:
-    image: "redis:8-alpine@sha256:8096655e437712b07503796fb64d81359256cfcff0ab29d95a7da72863786efb"
+    image: "redis:8-alpine"
     container_name: ${CONTAINER_NAME}-redis
     restart: unless-stopped
     networks:


### PR DESCRIPTION
## Summary

- Remove 2 digest pin(s) from images in the `latest` directory while retaining every image tag.
- This restores tag-based updates for Watchtower and similar tooling; fixed-version directories are unchanged.

## Verification

- The current moving tag advanced from the former digest and passed real 1Panel v2 install and readiness checks.
- The default user workflow persisted across an application restart performed through 1Panel, followed by successful uninstall and task-resource cleanup.
- Strict store validation with full strict i18n passed for all packaged versions: 0.25.3, latest.
- Docker Compose parsing passed for the submitted `latest` file.

Baseline: `9457ae896d598a9d8a7ec0c8a692af1d0138104e`