### PR TITLE
Allow Zerobyte latest image updates

### DIFF
--- a/apps/zerobyte/README.md
+++ b/apps/zerobyte/README.md
@@ -27,7 +27,7 @@ Zerobyte 当前没有针对备份操作的细粒度 RBAC。组织成员可以操
 
 ## 镜像安全说明
 
-固定的 v0.41.0 镜像无 Critical 漏洞，扫描报告包含七个 High 记录：rclone 的 TIFF 解码问题仅位于可选 Internxt 后端；gRPC 问题位于可选 GCS/Google Drive 客户端而非入站服务器或 xDS 控制面；Go `os.Root` 问题在 rclone、restic 和 shoutrrr 的对应源码版本中均无调用点。更换镜像 digest 后应重新评估这些结论。
+固定版本中的 v0.41.0 镜像快照无 Critical 漏洞，扫描报告包含七个 High 记录：rclone 的 TIFF 解码问题仅位于可选 Internxt 后端；gRPC 问题位于可选 GCS/Google Drive 客户端而非入站服务器或 xDS 控制面；Go `os.Root` 问题在 rclone、restic 和 shoutrrr 的对应源码版本中均无调用点。`latest` 目录使用移动标签，解析到新镜像后应重新评估这些结论。
 
 ## Introduction
 
@@ -56,4 +56,4 @@ Zerobyte does not currently provide fine-grained RBAC for backup operations. Org
 
 ## Image Security Note
 
-The pinned v0.41.0 image has no Critical findings and seven High records. The rclone TIFF issues are confined to the optional Internxt backend; the gRPC findings are in optional GCS/Google Drive clients rather than an inbound server or xDS control plane; and the affected rclone, restic, and shoutrrr source revisions contain no `os.Root` call site. Reassess these findings whenever the image digest changes.
+The image snapshot pinned by the fixed v0.41.0 package has no Critical findings and seven High records. The rclone TIFF issues are confined to the optional Internxt backend; the gRPC findings are in optional GCS/Google Drive clients rather than an inbound server or xDS control plane; and the affected rclone, restic, and shoutrrr source revisions contain no `os.Root` call site. The `latest` package follows a moving tag; reassess these findings after it resolves to a new image.

--- a/apps/zerobyte/latest/docker-compose.yml
+++ b/apps/zerobyte/latest/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   zerobyte:
-    image: "ghcr.io/nicotsx/zerobyte:latest@sha256:ace36f331f43429e5f9bf108fdffe6c23e0e64a59376ead5d36c8aca893c507d"
+    image: "ghcr.io/nicotsx/zerobyte:latest"
     container_name: ${CONTAINER_NAME}
     restart: always
     networks:


### PR DESCRIPTION
## Summary

- Remove 1 digest pin(s) from images in the `latest` directory while retaining every image tag.
- This restores tag-based updates for Watchtower and similar tooling; fixed-version directories are unchanged.

## Verification

- Registry comparison found the moving tag still resolves to the former pinned digest.
- Strict store validation with full strict i18n passed for all packaged versions: 0.41.0, latest.
- Docker Compose parsing passed for the submitted `latest` file.

Baseline: `9457ae896d598a9d8a7ec0c8a692af1d0138104e`