### PR TITLE
Allow Zipline latest image updates

### DIFF
--- a/apps/zipline/README.md
+++ b/apps/zipline/README.md
@@ -21,9 +21,9 @@ Zipline 是自托管的文件分享和 URL 缩短平台，提供用户管理、�
 ## 安全与部署风险
 
 - Zipline 以 UID/GID `1000:1000` 运行，数据库以 `70:70` 运行；两者均丢弃全部 Linux capabilities、使用只读根文件系统并启用 `no-new-privileges`。PostgreSQL 仅接入内部网络，不发布宿主端口。
-- 当前官方 `4.6.4` 镜像的新鲜双架构扫描仍包含上游漏洞。两份 Critical `CVE-2026-59873` 仅位于 npm/corepack 工具链，默认服务入口不调用这些工具。
+- 固定版本 `4.6.5` 使用的镜像快照在双架构扫描中仍包含上游漏洞。两份 Critical `CVE-2026-59873` 仅位于 npm/corepack 工具链，默认服务入口不调用这些工具。
 - `@fastify/static 9.1.3` 受 `CVE-2026-15074` 影响，但该公告仅允许绕过受保护 URL 前缀并读取同一静态根中的文件，不能越出静态根。Zipline 的 `build/client` 根本来就是公开前端资源；临时目录以 `serve:false` 注册，用户导出通过固定文件名和认证中间件发送。该默认路径例外不代表漏洞不存在。
-- 其余 High 位于构建工具、Prisma 迁移配置、静态 schema/路由依赖或需要 Zipline 默认监听器未启用的 HTTP/2/RSC 等功能。不要在容器内运行 npm/pnpm、载入不可信 Prisma 配置或改变官方入口；镜像摘要变化后必须重新扫描。
+- 其余 High 位于构建工具、Prisma 迁移配置、静态 schema/路由依赖或需要 Zipline 默认监听器未启用的 HTTP/2/RSC 等功能。不要在容器内运行 npm/pnpm、载入不可信 Prisma 配置或改变官方入口；移动 `latest` 标签解析到新镜像后必须重新扫描。
 
 ## Introduction
 
@@ -43,12 +43,12 @@ Zipline is a self-hosted file sharing and URL shortening platform with user mana
 
 ## Security Note
 
-The current official image contains upstream vulnerabilities. Two Critical `CVE-2026-59873` findings are confined to npm/corepack tooling that the default service entrypoint does not invoke. `CVE-2026-15074` in `@fastify/static 9.1.3` bypasses route-scoped guards but cannot escape a configured static root; Zipline exposes `build/client` as intentionally public, registers its temporary root with `serve:false`, and sends authenticated exports by a fixed server-selected filename. Other High findings are confined to build tooling, Prisma migration configuration, static schema/router dependencies, or features such as HTTP/2 and RSC that the default service does not enable. These are default-path reachability exceptions, not claims that the packages are absent. Running package managers in the container, loading untrusted Prisma configuration, or replacing the official entrypoint invalidates them.
+The audited official image snapshot contains upstream vulnerabilities. Two Critical `CVE-2026-59873` findings are confined to npm/corepack tooling that the default service entrypoint does not invoke. `CVE-2026-15074` in `@fastify/static 9.1.3` bypasses route-scoped guards but cannot escape a configured static root; Zipline exposes `build/client` as intentionally public, registers its temporary root with `serve:false`, and sends authenticated exports by a fixed server-selected filename. Other High findings are confined to build tooling, Prisma migration configuration, static schema/router dependencies, or features such as HTTP/2 and RSC that the default service does not enable. These are default-path reachability exceptions, not claims that the packages are absent from later images. A new image resolved from the moving `latest` tag, running package managers in the container, loading untrusted Prisma configuration, or replacing the official entrypoint invalidates them.
 
 ## References
 
 - Project: <https://github.com/diced/zipline>
 - Docker guide: <https://zipline.diced.sh/docs/get-started/docker>
-- Official Compose: <https://github.com/diced/zipline/blob/v4.6.4/docker-compose.yml>
-- License: <https://github.com/diced/zipline/blob/v4.6.4/LICENSE> (MIT)
+- Official Compose: <https://github.com/diced/zipline/blob/v4.6.5/docker-compose.yml>
+- License: <https://github.com/diced/zipline/blob/v4.6.5/LICENSE> (MIT)
 - Static advisory: <https://github.com/fastify/fastify-static/security/advisories/GHSA-83w8-p2f5-377r>

--- a/apps/zipline/latest/docker-compose.yml
+++ b/apps/zipline/latest/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   zipline-postgres:
-    image: postgres:16-alpine@sha256:57c72fd2a128e416c7fcc499958864df5301e940bca0a56f58fddf30ffc07777
+    image: postgres:16-alpine
     container_name: ${CONTAINER_NAME}-postgres
     restart: unless-stopped
     user: "70:70"
@@ -30,7 +30,7 @@ services:
       createdBy: "Apps"
 
   zipline:
-    image: ghcr.io/diced/zipline:latest@sha256:bfd5b0f7b5b8b3ed058a81667c78a14a7f997115d8433bec273620ec81be51d4
+    image: ghcr.io/diced/zipline:latest
     container_name: ${CONTAINER_NAME}
     restart: unless-stopped
     user: "1000:1000"


### PR DESCRIPTION
## Summary

- Remove 2 digest pin(s) from images in the `latest` directory while retaining every image tag.
- This restores tag-based updates for Watchtower and similar tooling; fixed-version directories are unchanged.

## Verification

- Registry comparison found the moving tag still resolves to the former pinned digest.
- Strict store validation with full strict i18n passed for all packaged versions: 4.6.5, latest.
- Docker Compose parsing passed for the submitted `latest` file.

Baseline: `9457ae896d598a9d8a7ec0c8a692af1d0138104e`