### PR TITLE
Format Ech0 i18n labels

### DIFF
--- a/apps/ech0/5.4.6/data.yml
+++ b/apps/ech0/5.4.6/data.yml
@@ -5,7 +5,15 @@ additionalProperties:
       envKey: PANEL_APP_PORT_HTTP
       labelEn: Web Port
       labelZh: Web 端口
-      label: {en: Web Port, zh: Web 端口, zh-Hant: Web 連接埠, ja: Web ポート, ko: Web 포트, ru: Веб-порт, ms: Port Web, pt-br: Porta Web}
+      label:
+        en: Web Port
+        zh: Web 端口
+        zh-Hant: Web 連接埠
+        ja: Web ポート
+        ko: Web 포트
+        ru: Веб-порт
+        ms: Port Web
+        pt-br: Porta Web
       required: true
       rule: paramPort
       type: number
@@ -14,7 +22,15 @@ additionalProperties:
       envKey: JWT_SECRET
       labelEn: JWT Secret
       labelZh: JWT 密钥
-      label: {en: JWT Secret, zh: JWT 密钥, zh-Hant: JWT 金鑰, ja: JWT シークレット, ko: JWT 비밀 키, ru: Секрет JWT, ms: Rahsia JWT, pt-br: Segredo JWT}
+      label:
+        en: JWT Secret
+        zh: JWT 密钥
+        zh-Hant: JWT 金鑰
+        ja: JWT シークレット
+        ko: JWT 비밀 키
+        ru: Секрет JWT
+        ms: Rahsia JWT
+        pt-br: Segredo JWT
       random: true
       required: true
       rule: paramComplexity
@@ -24,7 +40,15 @@ additionalProperties:
       envKey: APP_DATA_DIR
       labelEn: Data Directory
       labelZh: 数据目录
-      label: {en: Data Directory, zh: 数据目录, zh-Hant: 資料目錄, ja: データディレクトリ, ko: 데이터 디렉터리, ru: Каталог данных, ms: Direktori Data, pt-br: Diretório de Dados}
+      label:
+        en: Data Directory
+        zh: 数据目录
+        zh-Hant: 資料目錄
+        ja: データディレクトリ
+        ko: 데이터 디렉터리
+        ru: Каталог данных
+        ms: Direktori Data
+        pt-br: Diretório de Dados
       required: true
       type: text
     - default: Asia/Shanghai
@@ -32,6 +56,14 @@ additionalProperties:
       envKey: TZ
       labelEn: Timezone
       labelZh: 时区
-      label: {en: Timezone, zh: 时区, zh-Hant: 時區, ja: タイムゾーン, ko: 시간대, ru: Часовой пояс, ms: Zon Waktu, pt-br: Fuso Horário}
+      label:
+        en: Timezone
+        zh: 时区
+        zh-Hant: 時區
+        ja: タイムゾーン
+        ko: 시간대
+        ru: Часовой пояс
+        ms: Zon Waktu
+        pt-br: Fuso Horário
       required: true
       type: text

--- a/apps/ech0/latest/data.yml
+++ b/apps/ech0/latest/data.yml
@@ -5,7 +5,15 @@ additionalProperties:
       envKey: PANEL_APP_PORT_HTTP
       labelEn: Web Port
       labelZh: Web 端口
-      label: {en: Web Port, zh: Web 端口, zh-Hant: Web 連接埠, ja: Web ポート, ko: Web 포트, ru: Веб-порт, ms: Port Web, pt-br: Porta Web}
+      label:
+        en: Web Port
+        zh: Web 端口
+        zh-Hant: Web 連接埠
+        ja: Web ポート
+        ko: Web 포트
+        ru: Веб-порт
+        ms: Port Web
+        pt-br: Porta Web
       required: true
       rule: paramPort
       type: number
@@ -14,7 +22,15 @@ additionalProperties:
       envKey: JWT_SECRET
       labelEn: JWT Secret
       labelZh: JWT 密钥
-      label: {en: JWT Secret, zh: JWT 密钥, zh-Hant: JWT 金鑰, ja: JWT シークレット, ko: JWT 비밀 키, ru: Секрет JWT, ms: Rahsia JWT, pt-br: Segredo JWT}
+      label:
+        en: JWT Secret
+        zh: JWT 密钥
+        zh-Hant: JWT 金鑰
+        ja: JWT シークレット
+        ko: JWT 비밀 키
+        ru: Секрет JWT
+        ms: Rahsia JWT
+        pt-br: Segredo JWT
       random: true
       required: true
       rule: paramComplexity
@@ -24,7 +40,15 @@ additionalProperties:
       envKey: APP_DATA_DIR
       labelEn: Data Directory
       labelZh: 数据目录
-      label: {en: Data Directory, zh: 数据目录, zh-Hant: 資料目錄, ja: データディレクトリ, ko: 데이터 디렉터리, ru: Каталог данных, ms: Direktori Data, pt-br: Diretório de Dados}
+      label:
+        en: Data Directory
+        zh: 数据目录
+        zh-Hant: 資料目錄
+        ja: データディレクトリ
+        ko: 데이터 디렉터리
+        ru: Каталог данных
+        ms: Direktori Data
+        pt-br: Diretório de Dados
       required: true
       type: text
     - default: Asia/Shanghai
@@ -32,6 +56,14 @@ additionalProperties:
       envKey: TZ
       labelEn: Timezone
       labelZh: 时区
-      label: {en: Timezone, zh: 时区, zh-Hant: 時區, ja: タイムゾーン, ko: 시간대, ru: Часовой пояс, ms: Zon Waktu, pt-br: Fuso Horário}
+      label:
+        en: Timezone
+        zh: 时区
+        zh-Hant: 時區
+        ja: タイムゾーン
+        ko: 시간대
+        ru: Часовой пояс
+        ms: Zon Waktu
+        pt-br: Fuso Horário
       required: true
       type: text


### PR DESCRIPTION
## Summary

- Expand 8 inline multilingual label maps into readable YAML blocks.

## Verification

- Parsed YAML is structurally identical before and after formatting.
- Strict store validation with full strict i18n passed for all packaged versions: 5.4.6, latest.

Baseline: `9457ae896d598a9d8a7ec0c8a692af1d0138104e`