### PR TITLE
Format Flux Panel i18n labels

### DIFF
--- a/apps/flux-panel/1.4.3/data.yml
+++ b/apps/flux-panel/1.4.3/data.yml
@@ -5,7 +5,15 @@ additionalProperties:
       envKey: PANEL_APP_PORT_HTTP
       labelEn: Web Port
       labelZh: Web 端口
-      label: {en: Web Port, zh: Web 端口, zh-Hant: Web 連接埠, ja: Web ポート, ko: Web 포트, ru: Веб-порт, ms: Port Web, pt-br: Porta Web}
+      label:
+        en: Web Port
+        zh: Web 端口
+        zh-Hant: Web 連接埠
+        ja: Web ポート
+        ko: Web 포트
+        ru: Веб-порт
+        ms: Port Web
+        pt-br: Porta Web
       required: true
       rule: paramPort
       type: number
@@ -14,7 +22,15 @@ additionalProperties:
       envKey: DB_NAME
       labelEn: Database Name
       labelZh: 数据库名称
-      label: {en: Database Name, zh: 数据库名称, zh-Hant: 資料庫名稱, ja: データベース名, ko: 데이터베이스 이름, ru: Имя базы данных, ms: Nama Pangkalan Data, pt-br: Nome do Banco de Dados}
+      label:
+        en: Database Name
+        zh: 数据库名称
+        zh-Hant: 資料庫名稱
+        ja: データベース名
+        ko: 데이터베이스 이름
+        ru: Имя базы данных
+        ms: Nama Pangkalan Data
+        pt-br: Nome do Banco de Dados
       required: true
       rule: paramCommon
       type: text
@@ -23,7 +39,15 @@ additionalProperties:
       envKey: DB_USER
       labelEn: Database User
       labelZh: 数据库用户
-      label: {en: Database User, zh: 数据库用户, zh-Hant: 資料庫使用者, ja: データベースユーザー, ko: 데이터베이스 사용자, ru: Пользователь базы данных, ms: Pengguna Pangkalan Data, pt-br: Usuário do Banco de Dados}
+      label:
+        en: Database User
+        zh: 数据库用户
+        zh-Hant: 資料庫使用者
+        ja: データベースユーザー
+        ko: 데이터베이스 사용자
+        ru: Пользователь базы данных
+        ms: Pengguna Pangkalan Data
+        pt-br: Usuário do Banco de Dados
       required: true
       rule: paramCommon
       type: text
@@ -32,7 +56,15 @@ additionalProperties:
       envKey: DB_PASSWORD
       labelEn: Database Password
       labelZh: 数据库密码
-      label: {en: Database Password, zh: 数据库密码, zh-Hant: 資料庫密碼, ja: データベースパスワード, ko: 데이터베이스 비밀번호, ru: Пароль базы данных, ms: Kata Laluan Pangkalan Data, pt-br: Senha do Banco de Dados}
+      label:
+        en: Database Password
+        zh: 数据库密码
+        zh-Hant: 資料庫密碼
+        ja: データベースパスワード
+        ko: 데이터베이스 비밀번호
+        ru: Пароль базы данных
+        ms: Kata Laluan Pangkalan Data
+        pt-br: Senha do Banco de Dados
       random: true
       required: true
       rule: paramComplexity
@@ -42,7 +74,15 @@ additionalProperties:
       envKey: JWT_SECRET
       labelEn: JWT Secret
       labelZh: JWT 密钥
-      label: {en: JWT Secret, zh: JWT 密钥, zh-Hant: JWT 金鑰, ja: JWT シークレット, ko: JWT 비밀 키, ru: Секрет JWT, ms: Rahsia JWT, pt-br: Segredo JWT}
+      label:
+        en: JWT Secret
+        zh: JWT 密钥
+        zh-Hant: JWT 金鑰
+        ja: JWT シークレット
+        ko: JWT 비밀 키
+        ru: Секрет JWT
+        ms: Rahsia JWT
+        pt-br: Segredo JWT
       random: true
       required: true
       rule: paramComplexity
@@ -52,7 +92,15 @@ additionalProperties:
       envKey: APP_DATA_DIR
       labelEn: Data Directory
       labelZh: 数据目录
-      label: {en: Data Directory, zh: 数据目录, zh-Hant: 資料目錄, ja: データディレクトリ, ko: 데이터 디렉터리, ru: Каталог данных, ms: Direktori Data, pt-br: Diretório de Dados}
+      label:
+        en: Data Directory
+        zh: 数据目录
+        zh-Hant: 資料目錄
+        ja: データディレクトリ
+        ko: 데이터 디렉터리
+        ru: Каталог данных
+        ms: Direktori Data
+        pt-br: Diretório de Dados
       required: true
       type: text
     - default: Asia/Shanghai
@@ -60,6 +108,14 @@ additionalProperties:
       envKey: TZ
       labelEn: Timezone
       labelZh: 时区
-      label: {en: Timezone, zh: 时区, zh-Hant: 時區, ja: タイムゾーン, ko: 시간대, ru: Часовой пояс, ms: Zon Waktu, pt-br: Fuso Horário}
+      label:
+        en: Timezone
+        zh: 时区
+        zh-Hant: 時區
+        ja: タイムゾーン
+        ko: 시간대
+        ru: Часовой пояс
+        ms: Zon Waktu
+        pt-br: Fuso Horário
       required: true
       type: text


### PR DESCRIPTION
## Summary

- Expand 7 inline multilingual label maps into readable YAML blocks.

## Verification

- Parsed YAML is structurally identical before and after formatting.
- Strict store validation with full strict i18n passed for all packaged versions: 1.4.3.

Baseline: `9457ae896d598a9d8a7ec0c8a692af1d0138104e`