### PR TITLE
Format MosDNS-T i18n labels

### DIFF
--- a/apps/mosdns-t/0.7.1/data.yml
+++ b/apps/mosdns-t/0.7.1/data.yml
@@ -5,7 +5,15 @@ additionalProperties:
       envKey: PANEL_APP_PORT_DNS
       labelEn: DNS Port
       labelZh: DNS 端口
-      label: {en: DNS Port, zh: DNS 端口, zh-Hant: DNS 連接埠, ja: DNS ポート, ko: DNS 포트, ru: Порт DNS, ms: Port DNS, pt-br: Porta DNS}
+      label:
+        en: DNS Port
+        zh: DNS 端口
+        zh-Hant: DNS 連接埠
+        ja: DNS ポート
+        ko: DNS 포트
+        ru: Порт DNS
+        ms: Port DNS
+        pt-br: Porta DNS
       required: true
       rule: paramPort
       type: number
@@ -14,7 +22,15 @@ additionalProperties:
       envKey: PANEL_APP_PORT_HTTP
       labelEn: WebUI Port
       labelZh: WebUI 端口
-      label: {en: WebUI Port, zh: WebUI 端口, zh-Hant: WebUI 連接埠, ja: WebUI ポート, ko: WebUI 포트, ru: Порт WebUI, ms: Port WebUI, pt-br: Porta WebUI}
+      label:
+        en: WebUI Port
+        zh: WebUI 端口
+        zh-Hant: WebUI 連接埠
+        ja: WebUI ポート
+        ko: WebUI 포트
+        ru: Порт WebUI
+        ms: Port WebUI
+        pt-br: Porta WebUI
       required: true
       rule: paramPort
       type: number
@@ -23,6 +39,14 @@ additionalProperties:
       envKey: APP_DATA_DIR
       labelEn: Data Directory
       labelZh: 数据目录
-      label: {en: Data Directory, zh: 数据目录, zh-Hant: 資料目錄, ja: データディレクトリ, ko: 데이터 디렉터리, ru: Каталог данных, ms: Direktori Data, pt-br: Diretório de Dados}
+      label:
+        en: Data Directory
+        zh: 数据目录
+        zh-Hant: 資料目錄
+        ja: データディレクトリ
+        ko: 데이터 디렉터리
+        ru: Каталог данных
+        ms: Direktori Data
+        pt-br: Diretório de Dados
       required: true
       type: text

--- a/apps/mosdns-t/latest/data.yml
+++ b/apps/mosdns-t/latest/data.yml
@@ -5,7 +5,15 @@ additionalProperties:
       envKey: PANEL_APP_PORT_DNS
       labelEn: DNS Port
       labelZh: DNS 端口
-      label: {en: DNS Port, zh: DNS 端口, zh-Hant: DNS 連接埠, ja: DNS ポート, ko: DNS 포트, ru: Порт DNS, ms: Port DNS, pt-br: Porta DNS}
+      label:
+        en: DNS Port
+        zh: DNS 端口
+        zh-Hant: DNS 連接埠
+        ja: DNS ポート
+        ko: DNS 포트
+        ru: Порт DNS
+        ms: Port DNS
+        pt-br: Porta DNS
       required: true
       rule: paramPort
       type: number
@@ -14,7 +22,15 @@ additionalProperties:
       envKey: PANEL_APP_PORT_HTTP
       labelEn: WebUI Port
       labelZh: WebUI 端口
-      label: {en: WebUI Port, zh: WebUI 端口, zh-Hant: WebUI 連接埠, ja: WebUI ポート, ko: WebUI 포트, ru: Порт WebUI, ms: Port WebUI, pt-br: Porta WebUI}
+      label:
+        en: WebUI Port
+        zh: WebUI 端口
+        zh-Hant: WebUI 連接埠
+        ja: WebUI ポート
+        ko: WebUI 포트
+        ru: Порт WebUI
+        ms: Port WebUI
+        pt-br: Porta WebUI
       required: true
       rule: paramPort
       type: number
@@ -23,6 +39,14 @@ additionalProperties:
       envKey: APP_DATA_DIR
       labelEn: Data Directory
       labelZh: 数据目录
-      label: {en: Data Directory, zh: 数据目录, zh-Hant: 資料目錄, ja: データディレクトリ, ko: 데이터 디렉터리, ru: Каталог данных, ms: Direktori Data, pt-br: Diretório de Dados}
+      label:
+        en: Data Directory
+        zh: 数据目录
+        zh-Hant: 資料目錄
+        ja: データディレクトリ
+        ko: 데이터 디렉터리
+        ru: Каталог данных
+        ms: Direktori Data
+        pt-br: Diretório de Dados
       required: true
       type: text


### PR DESCRIPTION
## Summary

- Expand 6 inline multilingual label maps into readable YAML blocks.

## Verification

- Parsed YAML is structurally identical before and after formatting.
- Strict store validation with full strict i18n passed for all packaged versions: 0.7.1, latest.

Baseline: `9457ae896d598a9d8a7ec0c8a692af1d0138104e`