### PR TITLE
Format Xiaomi Album Syncer i18n labels

### DIFF
--- a/apps/xiaomi-album-syncer/0.17.0/data.yml
+++ b/apps/xiaomi-album-syncer/0.17.0/data.yml
@@ -5,7 +5,15 @@ additionalProperties:
       envKey: PANEL_APP_PORT_HTTP
       labelEn: Web Port
       labelZh: Web 端口
-      label: {en: Web Port, zh: Web 端口, zh-Hant: Web 連接埠, ja: Web ポート, ko: Web 포트, ru: Веб-порт, ms: Port Web, pt-br: Porta Web}
+      label:
+        en: Web Port
+        zh: Web 端口
+        zh-Hant: Web 連接埠
+        ja: Web ポート
+        ko: Web 포트
+        ru: Веб-порт
+        ms: Port Web
+        pt-br: Porta Web
       required: true
       rule: paramPort
       type: number
@@ -14,7 +22,15 @@ additionalProperties:
       envKey: DOWNLOAD_DIR
       labelEn: Download Directory
       labelZh: 下载目录
-      label: {en: Download Directory, zh: 下载目录, zh-Hant: 下載目錄, ja: ダウンロードディレクトリ, ko: 다운로드 디렉터리, ru: Каталог загрузок, ms: Direktori Muat Turun, pt-br: Diretório de Downloads}
+      label:
+        en: Download Directory
+        zh: 下载目录
+        zh-Hant: 下載目錄
+        ja: ダウンロードディレクトリ
+        ko: 다운로드 디렉터리
+        ru: Каталог загрузок
+        ms: Direktori Muat Turun
+        pt-br: Diretório de Downloads
       required: true
       type: text
     - default: ./data/db
@@ -22,7 +38,15 @@ additionalProperties:
       envKey: DATABASE_DIR
       labelEn: Database Directory
       labelZh: 数据库目录
-      label: {en: Database Directory, zh: 数据库目录, zh-Hant: 資料庫目錄, ja: データベースディレクトリ, ko: 데이터베이스 디렉터리, ru: Каталог базы данных, ms: Direktori Pangkalan Data, pt-br: Diretório do Banco de Dados}
+      label:
+        en: Database Directory
+        zh: 数据库目录
+        zh-Hant: 資料庫目錄
+        ja: データベースディレクトリ
+        ko: 데이터베이스 디렉터리
+        ru: Каталог базы данных
+        ms: Direktori Pangkalan Data
+        pt-br: Diretório do Banco de Dados
       required: true
       type: text
     - default: Asia/Shanghai
@@ -30,6 +54,14 @@ additionalProperties:
       envKey: TZ
       labelEn: Timezone
       labelZh: 时区
-      label: {en: Timezone, zh: 时区, zh-Hant: 時區, ja: タイムゾーン, ko: 시간대, ru: Часовой пояс, ms: Zon Waktu, pt-br: Fuso Horário}
+      label:
+        en: Timezone
+        zh: 时区
+        zh-Hant: 時區
+        ja: タイムゾーン
+        ko: 시간대
+        ru: Часовой пояс
+        ms: Zon Waktu
+        pt-br: Fuso Horário
       required: true
       type: text

--- a/apps/xiaomi-album-syncer/latest/data.yml
+++ b/apps/xiaomi-album-syncer/latest/data.yml
@@ -5,7 +5,15 @@ additionalProperties:
       envKey: PANEL_APP_PORT_HTTP
       labelEn: Web Port
       labelZh: Web 端口
-      label: {en: Web Port, zh: Web 端口, zh-Hant: Web 連接埠, ja: Web ポート, ko: Web 포트, ru: Веб-порт, ms: Port Web, pt-br: Porta Web}
+      label:
+        en: Web Port
+        zh: Web 端口
+        zh-Hant: Web 連接埠
+        ja: Web ポート
+        ko: Web 포트
+        ru: Веб-порт
+        ms: Port Web
+        pt-br: Porta Web
       required: true
       rule: paramPort
       type: number
@@ -14,7 +22,15 @@ additionalProperties:
       envKey: DOWNLOAD_DIR
       labelEn: Download Directory
       labelZh: 下载目录
-      label: {en: Download Directory, zh: 下载目录, zh-Hant: 下載目錄, ja: ダウンロードディレクトリ, ko: 다운로드 디렉터리, ru: Каталог загрузок, ms: Direktori Muat Turun, pt-br: Diretório de Downloads}
+      label:
+        en: Download Directory
+        zh: 下载目录
+        zh-Hant: 下載目錄
+        ja: ダウンロードディレクトリ
+        ko: 다운로드 디렉터리
+        ru: Каталог загрузок
+        ms: Direktori Muat Turun
+        pt-br: Diretório de Downloads
       required: true
       type: text
     - default: ./data/db
@@ -22,7 +38,15 @@ additionalProperties:
       envKey: DATABASE_DIR
       labelEn: Database Directory
       labelZh: 数据库目录
-      label: {en: Database Directory, zh: 数据库目录, zh-Hant: 資料庫目錄, ja: データベースディレクトリ, ko: 데이터베이스 디렉터리, ru: Каталог базы данных, ms: Direktori Pangkalan Data, pt-br: Diretório do Banco de Dados}
+      label:
+        en: Database Directory
+        zh: 数据库目录
+        zh-Hant: 資料庫目錄
+        ja: データベースディレクトリ
+        ko: 데이터베이스 디렉터리
+        ru: Каталог базы данных
+        ms: Direktori Pangkalan Data
+        pt-br: Diretório do Banco de Dados
       required: true
       type: text
     - default: Asia/Shanghai
@@ -30,6 +54,14 @@ additionalProperties:
       envKey: TZ
       labelEn: Timezone
       labelZh: 时区
-      label: {en: Timezone, zh: 时区, zh-Hant: 時區, ja: タイムゾーン, ko: 시간대, ru: Часовой пояс, ms: Zon Waktu, pt-br: Fuso Horário}
+      label:
+        en: Timezone
+        zh: 时区
+        zh-Hant: 時區
+        ja: タイムゾーン
+        ko: 시간대
+        ru: Часовой пояс
+        ms: Zon Waktu
+        pt-br: Fuso Horário
       required: true
       type: text


### PR DESCRIPTION
## Summary

- Expand 8 inline multilingual label maps into readable YAML blocks.

## Verification

- Parsed YAML is structurally identical before and after formatting.
- Strict store validation with full strict i18n passed for all packaged versions: 0.17.0, latest.

Baseline: `9457ae896d598a9d8a7ec0c8a692af1d0138104e`