### PR TITLE
ci: whitelist stable Renovate apps

### DIFF
--- a/.github/renovate-automerge-whitelist.txt
+++ b/.github/renovate-automerge-whitelist.txt
@@ -374,3 +374,7 @@ ech0
 flipt
 helium-linuxserver
 wakapi
+
+# Reviewed single-service Renovate candidates (2026-08-01).
+codex2api
+opencode


### PR DESCRIPTION
## Summary

- add codex2api to the Renovate automerge whitelist after eight image-only updates and upgrade validation
- add opencode after three image-only updates and stable single-service packaging

## Validation

- candidate whitelist audit for codex2api and opencode
- Renovate policy test suite: 41 tests
- duplicate-entry check
- git diff whitespace check