### PR TITLE
ci: whitelist digest-only Renovate apps

### DIFF
--- a/.github/renovate-automerge-whitelist.txt
+++ b/.github/renovate-automerge-whitelist.txt
@@ -378,3 +378,26 @@ wakapi
 # Reviewed single-service Renovate candidates (2026-08-01).
 codex2api
 opencode
+
+# Reviewed digest-only Renovate candidates (2026-08-07).
+podfetch
+isrvd
+chromium-kasm
+filezilla-kasm
+firefox-kasm
+insomnia-kasm
+only-office-kasm
+postman-kasm
+signal-kasm
+slack-kasm
+vlc-kasm
+audacity-kasm
+blender-kasm
+brave-kasm
+gimp-kasm
+inkscape-kasm
+obsidian-kasm
+pinta-kasm
+remmina-kasm
+sublime-text-kasm
+vivaldi-kasm


### PR DESCRIPTION
Add the 21 currently open single-service digest-only Renovate app keys to the strict automerge whitelist. Each candidate passed the repository whitelist audit; the automerge workflow still independently enforces app-only scope, one service, image-only Compose changes, and the app-version marker.\n\nValidation: 21/21 heuristic candidates eligible; renovate app-version tests 42/42; sidecar guard tests 12/12; no duplicate whitelist entries.