### PR TITLE
chore: expand Renovate automerge whitelist

### DIFF
--- a/.github/renovate-automerge-whitelist.txt
+++ b/.github/renovate-automerge-whitelist.txt
@@ -401,3 +401,8 @@ pinta-kasm
 remmina-kasm
 sublime-text-kasm
 vivaldi-kasm
+
+# Reviewed single-service Renovate candidates (2026-08-10).
+filerise
+hermitstash
+pulse


### PR DESCRIPTION
## Summary

- add filerise, hermitstash, and pulse to the reviewed Renovate automerge whitelist
- keep the existing whitelist order and append a dated review batch

## Evidence

- all three are single-service with stable compose shape and no special runtime flags
- retained upgrade smoke reports cover two consecutive updates for each app
- retained same-database image comparisons show no introduced or worsened High or Critical findings

## Verification

- python3 .github/scripts/renovate_whitelist_audit.py --app filerise --app hermitstash --app pulse
- python3 .github/scripts/test_renovate_app_version.py
- whitelist contains 389 unique entries