### PR TITLE
Fix Piper config path compatibility after 2.4.2 update

### DIFF
--- a/apps/piper-linuxserver/2.4.2/.env.sample
+++ b/apps/piper-linuxserver/2.4.2/.env.sample
@@ -1,5 +1,6 @@
 CONTAINER_NAME=piper-linuxserver-compose-check
 PANEL_APP_PORT_WYOMING=10200
+CONFIG_PATH=./data/config
 TIME_ZONE=Asia/Shanghai
 PIPER_VOICE=en_US-lessac-medium
 LOCAL_ONLY=

--- a/apps/piper-linuxserver/2.4.2/data.yml
+++ b/apps/piper-linuxserver/2.4.2/data.yml
@@ -18,7 +18,7 @@ additionalProperties:
     type: number
     rule: paramPort
   - default: ./data/config
-    edit: false
+    edit: true
     envKey: CONFIG_PATH
     labelEn: Config folder path
     labelZh: 配置文件路径
@@ -171,19 +171,3 @@ additionalProperties:
       value: ''
     - label: 'true'
       value: 'true'
-  - default: Asia/Shanghai
-    edit: true
-    envKey: TZ
-    labelEn: Timezone
-    labelZh: 时区
-    label:
-      en: Timezone
-      zh: 时区
-      zh-Hant: 時區
-      ja: タイムゾーン
-      ko: 시간대
-      ru: Часовой пояс
-      ms: Zon waktu
-      pt-br: Fuso horário
-    required: true
-    type: text

--- a/apps/piper-linuxserver/2.4.2/docker-compose.yml
+++ b/apps/piper-linuxserver/2.4.2/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     ports:
       - "${PANEL_APP_PORT_WYOMING}:10200"
     volumes:
-      - "./data/config:/config"
+      - "${CONFIG_PATH}:/config"
     environment:
       - PUID=1000
       - PGID=1000


### PR DESCRIPTION
Follow-up to merged Piper maintenance PR #6083 (source update #5867).\n\n- Restore CONFIG_PATH:/config and keep CONFIG_PATH editable for existing installations.\n- Add CONFIG_PATH back to the 2.4.2 env sample.\n- Remove the unused duplicate TZ field; TIME_ZONE remains the variable consumed by Compose.\n- Verified adapter validation, custom Compose rendering, init idempotence, and upgrade.sh preservation of CONFIG_PATH=./legacy-config.