### PR TITLE
Fix Pocket ID environment contract after 2.14.0 update

### DIFF
--- a/apps/pocket-id/2.14.0-distroless/data.yml
+++ b/apps/pocket-id/2.14.0-distroless/data.yml
@@ -66,19 +66,3 @@ additionalProperties:
       pt-br: Enderecos de proxy confiaveis
     required: true
     type: text
-  - default: Asia/Shanghai
-    edit: true
-    envKey: TZ
-    labelEn: Timezone
-    labelZh: 时区
-    label:
-      en: Timezone
-      zh: 时区
-      zh-Hant: 時區
-      ja: タイムゾーン
-      ko: 시간대
-      ru: Часовой пояс
-      ms: Zon waktu
-      pt-br: Fuso horário
-    required: true
-    type: text


### PR DESCRIPTION
Follow-up to merged Pocket ID maintenance PR #6075 (source update #6001).\n\n- Remove the added TZ form field because the Compose file does not consume it and the env sample does not declare it.\n- Keep the existing application variables unchanged.\n- Verified strict adapter validation and env-field/sample consistency.