### PR TITLE
fix: use versioned image tags and simplify lifecycle scripts

### DIFF
--- a/apps/cloudflare-mesh/README.md
+++ b/apps/cloudflare-mesh/README.md
@@ -23,7 +23,7 @@ Cloudflare Mesh 是 Cloudflare One 的私有网络连接器容器。它没有 We
 
 容器镜像使用 Cloudflare 产品条款，Cloudflare Mesh 连接器并非本适配项目重新编译的开源镜像。部署和再分发时请遵守 [Cloudflare Terms](https://www.cloudflare.com/terms/) 以及 Cloudflare One 的产品条款。
 
-当前固定镜像快照的扫描还发现了未解决的 High 级基础镜像告警（`CVE-2026-38754`、`CVE-2026-14456`，涉及 BusyBox/OpenSSL 软件包）。这些问题位于厂商镜像内部，本适配不会自行修补；请关注 Cloudflare 发布的修复镜像并及时更新 digest。
+当前使用的 `2026.7.0` 镜像版本扫描还发现了未解决的 High 级基础镜像告警（`CVE-2026-38754`、`CVE-2026-14456`，涉及 BusyBox/OpenSSL 软件包）。这些问题位于厂商镜像内部，本适配不会自行修补；请关注 Cloudflare 发布的修复镜像并及时更新镜像 tag。
 
 ## 数据与升级
 
@@ -65,7 +65,7 @@ The connector requires these permissions for its core function and they must rem
 
 The image contains Cloudflare product software and is not rebuilt as an open-source image by this package. Follow the [Cloudflare Terms](https://www.cloudflare.com/terms/) and Cloudflare One product terms when deploying or redistributing it.
 
-The pinned image snapshot also has unresolved High-severity base-image findings (`CVE-2026-38754` and `CVE-2026-14456`, affecting BusyBox/OpenSSL packages). They are inside the vendor image and are not patched by this package; review the image digest and update when Cloudflare publishes a fixed build.
+The currently used `2026.7.0` image version also has unresolved High-severity base-image findings (`CVE-2026-38754` and `CVE-2026-14456`, affecting BusyBox/OpenSSL packages). They are inside the vendor image and are not patched by this package; update the image tag when Cloudflare publishes a fixed build.
 
 ## Data and upgrades
 

--- a/apps/cloudflare-mesh/latest/docker-compose.yml
+++ b/apps/cloudflare-mesh/latest/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   cloudflare-mesh:
-    image: cloudflare/mesh@sha256:18fad6d500e8ca48b7e4d5ae1905d65e8a50c1f5f5e21eba020d54d5cbf82571
+    image: cloudflare/mesh:2026.7.0
     container_name: ${CONTAINER_NAME}
     restart: unless-stopped
     cap_add:

--- a/apps/cloudflare-mesh/latest/scripts/init.sh
+++ b/apps/cloudflare-mesh/latest/scripts/init.sh
@@ -1,31 +1,5 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
-ENV_FILE="${ENV_FILE:-${ROOT_DIR}/.env}"
-
-fail() {
-  printf '%s\n' "$1" >&2
-  exit 1
-}
-
-read_env_value() {
-  local key="$1"
-  local value
-
-  value="$(sed -n -E "s/^${key}=//p" "$ENV_FILE" | tail -n 1 || true)"
-  case "$value" in
-    \"*\") value="${value#\"}"; value="${value%\"}" ;;
-    \'*\') value="${value#\'}"; value="${value%\'}" ;;
-  esac
-  printf '%s\n' "$value"
-}
-
-[[ -f "$ENV_FILE" && ! -L "$ENV_FILE" ]] || fail "Environment file is missing or is a symbolic link"
-
-node_token="$(read_env_value MESH_NODE_TOKEN)"
-[[ -n "$node_token" && "$node_token" != replace-with-* ]] || fail "MESH_NODE_TOKEN must be configured"
-[[ "$node_token" != *[[:space:]]* ]] || fail "MESH_NODE_TOKEN contains whitespace"
-
-srcnat_enabled="$(read_env_value SRCNAT_ENABLED)"
-[[ "$srcnat_enabled" == true || "$srcnat_enabled" == false ]] || fail "SRCNAT_ENABLED must be true or false"
+# Mesh configuration is supplied by the 1Panel form and Compose file.
+exit 0

--- a/apps/cloudflare-mesh/latest/scripts/upgrade.sh
+++ b/apps/cloudflare-mesh/latest/scripts/upgrade.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
-exec "$ROOT_DIR/scripts/init.sh"
+# Mesh state is preserved in the mesh_data volume; reset-registration.sh is explicit.
+exit 0

--- a/apps/kan/0.6.0/docker-compose.yml
+++ b/apps/kan/0.6.0/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   kan:
-    image: ghcr.io/kanbn/kan@sha256:0087a72a123d8462c66ddce3a303049d4ec92f03cfba297d41466605ef8cb5b5
+    image: ghcr.io/kanbn/kan:0.6.0
     container_name: ${CONTAINER_NAME}
     restart: unless-stopped
     depends_on:
@@ -21,7 +21,7 @@ services:
       createdBy: "Apps"
 
   kan-migrate:
-    image: ghcr.io/kanbn/kan-migrate@sha256:3296fd28e037a93dda478981494a72c6905ecd4f0d0739e79139172844acbc4b
+    image: ghcr.io/kanbn/kan-migrate:0.6.0
     container_name: ${CONTAINER_NAME}-migrate
     restart: unless-stopped
     networks:

--- a/apps/kan/0.6.0/scripts/init.sh
+++ b/apps/kan/0.6.0/scripts/init.sh
@@ -21,32 +21,10 @@ read_env_value() {
   printf '%s\n' "$value"
 }
 
-validate_port() {
-  local key="$1"
-  local value="$2"
-
-  [[ "$value" =~ ^[0-9]+$ ]] || fail "$key must be an integer"
-  ((10#$value >= 1 && 10#$value <= 65535)) || fail "$key must be between 1 and 65535"
-}
-
 [[ -f "$ENV_FILE" && ! -L "$ENV_FILE" ]] || fail "Environment file is missing or is a symbolic link"
-
-public_url="$(read_env_value NEXT_PUBLIC_BASE_URL)"
-[[ "$public_url" =~ ^https?://[^[:space:]]+$ ]] || fail "NEXT_PUBLIC_BASE_URL must be a complete HTTP(S) URL"
 
 better_auth_secret="$(read_env_value BETTER_AUTH_SECRET)"
 [[ ${#better_auth_secret} -ge 32 ]] || fail "BETTER_AUTH_SECRET must contain at least 32 characters"
 
-db_host="$(read_env_value PANEL_DB_HOST)"
-db_type="$(read_env_value PANEL_DB_TYPE)"
-db_port="$(read_env_value PANEL_DB_PORT)"
-db_name="$(read_env_value PANEL_DB_NAME)"
-db_user="$(read_env_value PANEL_DB_USER)"
 db_password="$(read_env_value PANEL_DB_USER_PASSWORD)"
-
-[[ "$db_host" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]] || fail "PANEL_DB_HOST is invalid"
-[[ "$db_type" == postgresql ]] || fail "PANEL_DB_TYPE must be postgresql"
-validate_port PANEL_DB_PORT "$db_port"
-[[ "$db_name" =~ ^[A-Za-z0-9_][A-Za-z0-9_-]*$ ]] || fail "PANEL_DB_NAME is invalid"
-[[ "$db_user" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]*$ ]] || fail "PANEL_DB_USER is invalid"
 [[ "$db_password" =~ ^[A-Za-z0-9._~-]+$ ]] || fail "PANEL_DB_USER_PASSWORD must use URL-safe characters"

--- a/apps/kan/0.6.0/scripts/upgrade.sh
+++ b/apps/kan/0.6.0/scripts/upgrade.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# No legacy Kan package was released. Keep the 1Panel upgrade hook a no-op.
+# Kan has no previously released package requiring a migration.
 exit 0

--- a/apps/kan/README.md
+++ b/apps/kan/README.md
@@ -27,7 +27,7 @@ PostgreSQL 数据由所选的 1Panel 数据库应用负责持久化，Kan 卸载
 
 ## 安全提醒
 
-本适配直接使用 Kan 官方发布的 Web 与迁移容器镜像，没有在适配层重打包或修补上游代码。针对当前官方镜像快照的扫描发现了 Critical/High 级别依赖告警，涉及 Web 身份认证/解析依赖和迁移镜像工具链；这不代表所有问题都能从 Kan 入口利用，但也不能视为已经修复。按用户授权保留这些官方镜像并在此处明确告警；生产环境请限制管理入口、使用 HTTPS，分别关注 Kan 与所选 PostgreSQL 镜像的安全更新。
+本适配直接使用 Kan 官方发布的 Web 与迁移容器镜像，没有在适配层重打包或修补上游代码。针对当前使用的官方 `0.6.0` 镜像版本扫描发现了 Critical/High 级别依赖告警，涉及 Web 身份认证/解析依赖和迁移镜像工具链；这不代表所有问题都能从 Kan 入口利用，但也不能视为已经修复。按用户授权保留这些官方镜像并在此处明确告警；生产环境请限制管理入口、使用 HTTPS，分别关注 Kan 与所选 PostgreSQL 镜像的安全更新。
 
 Kan 采用 AGPLv3；分发修改后的应用或镜像时，请遵守上游许可证及源码提供义务：[LICENSE](https://github.com/kanbn/kan/blob/v0.6.0/LICENSE)。
 
@@ -56,6 +56,6 @@ Kan is a self-hosted project management tool for teams. It provides boards, work
 
 ## Security notice
 
-This package uses Kan's official published web and migration images without repacking or patching the upstream code. The current official image snapshot has Critical/High dependency findings in the web authentication/parser dependencies and migration toolchain. These findings are not a claim that every item is exploitable through Kan, but they are also not treated as fixed. The images are retained under the user's authorization with this warning; restrict administrative access, use HTTPS, and track security updates for both Kan and the selected PostgreSQL image.
+This package uses Kan's official published web and migration images without repacking or patching the upstream code. Scans of the currently used official `0.6.0` image version found Critical/High dependency findings in the web authentication/parser dependencies and migration toolchain. These findings are not a claim that every item is exploitable through Kan, but they are also not treated as fixed. The images are retained under the user's authorization with this warning; restrict administrative access, use HTTPS, and track security updates for both Kan and the selected PostgreSQL image.
 
 Kan is licensed under AGPLv3. Follow the upstream license and source-disclosure obligations when distributing modified applications or images: [LICENSE](https://github.com/kanbn/kan/blob/v0.6.0/LICENSE).

--- a/apps/kan/latest/docker-compose.yml
+++ b/apps/kan/latest/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   kan:
-    image: ghcr.io/kanbn/kan@sha256:0087a72a123d8462c66ddce3a303049d4ec92f03cfba297d41466605ef8cb5b5
+    image: ghcr.io/kanbn/kan:0.6.0
     container_name: ${CONTAINER_NAME}
     restart: unless-stopped
     depends_on:
@@ -21,7 +21,7 @@ services:
       createdBy: "Apps"
 
   kan-migrate:
-    image: ghcr.io/kanbn/kan-migrate@sha256:3296fd28e037a93dda478981494a72c6905ecd4f0d0739e79139172844acbc4b
+    image: ghcr.io/kanbn/kan-migrate:0.6.0
     container_name: ${CONTAINER_NAME}-migrate
     restart: unless-stopped
     networks:

--- a/apps/kan/latest/scripts/init.sh
+++ b/apps/kan/latest/scripts/init.sh
@@ -21,32 +21,10 @@ read_env_value() {
   printf '%s\n' "$value"
 }
 
-validate_port() {
-  local key="$1"
-  local value="$2"
-
-  [[ "$value" =~ ^[0-9]+$ ]] || fail "$key must be an integer"
-  ((10#$value >= 1 && 10#$value <= 65535)) || fail "$key must be between 1 and 65535"
-}
-
 [[ -f "$ENV_FILE" && ! -L "$ENV_FILE" ]] || fail "Environment file is missing or is a symbolic link"
-
-public_url="$(read_env_value NEXT_PUBLIC_BASE_URL)"
-[[ "$public_url" =~ ^https?://[^[:space:]]+$ ]] || fail "NEXT_PUBLIC_BASE_URL must be a complete HTTP(S) URL"
 
 better_auth_secret="$(read_env_value BETTER_AUTH_SECRET)"
 [[ ${#better_auth_secret} -ge 32 ]] || fail "BETTER_AUTH_SECRET must contain at least 32 characters"
 
-db_host="$(read_env_value PANEL_DB_HOST)"
-db_type="$(read_env_value PANEL_DB_TYPE)"
-db_port="$(read_env_value PANEL_DB_PORT)"
-db_name="$(read_env_value PANEL_DB_NAME)"
-db_user="$(read_env_value PANEL_DB_USER)"
 db_password="$(read_env_value PANEL_DB_USER_PASSWORD)"
-
-[[ "$db_host" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]] || fail "PANEL_DB_HOST is invalid"
-[[ "$db_type" == postgresql ]] || fail "PANEL_DB_TYPE must be postgresql"
-validate_port PANEL_DB_PORT "$db_port"
-[[ "$db_name" =~ ^[A-Za-z0-9_][A-Za-z0-9_-]*$ ]] || fail "PANEL_DB_NAME is invalid"
-[[ "$db_user" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]*$ ]] || fail "PANEL_DB_USER is invalid"
 [[ "$db_password" =~ ^[A-Za-z0-9._~-]+$ ]] || fail "PANEL_DB_USER_PASSWORD must use URL-safe characters"

--- a/apps/kan/latest/scripts/upgrade.sh
+++ b/apps/kan/latest/scripts/upgrade.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# No legacy Kan package was released. Keep the 1Panel upgrade hook a no-op.
+# Kan has no previously released package requiring a migration.
 exit 0


### PR DESCRIPTION
## Summary
- use concrete release tags for Kan and Cloudflare Mesh without binding image references to digests
- keep only Kan lifecycle validation that protects the raw PostgreSQL URL and authentication secret
- keep the required 1Panel lifecycle entrypoints minimal and preserve Mesh's explicit, guarded registration-reset workflow

## Validation
- Bash syntax and ShellCheck passed for all Kan/Mesh lifecycle scripts
- Kan valid and invalid configuration fixtures passed
- `validate-v2.sh` baseline passed for Kan `latest`, Kan `0.6.0`, and Mesh `latest`
- `.env.sample` closure passed for all delivered versions

The local strict validator still reports the pre-existing missing `source-evidence.json`; this change does not alter that evidence boundary.