### PR TITLE
feat(deepseek-harness): update workstation to v0.1.2-alpha.1

### DIFF
--- a/apps/deepseek-harness-workstation/0.1.2-alpha.1/.env.sample
+++ b/apps/deepseek-harness-workstation/0.1.2-alpha.1/.env.sample
@@ -1,0 +1,10 @@
+CONTAINER_NAME=deepseek-harness-workstation-compose-check
+PANEL_APP_PORT_HTTP=56789
+TZ=Asia/Shanghai
+DSH_PUBLIC_URL=https://dsh.example.com
+DSH_AUTH_USERNAME=admin
+DSH_AUTH_PASSWORD=replace-with-a-unique-password-at-least-12-characters
+DSH_AUTH_TOKEN_LIFETIME=604800
+CADDY_TRUSTED_PROXIES=private_ranges
+DSH_TRUSTED_HOSTS=
+DOCKER_SOCK_PATH=/dev/null

--- a/apps/deepseek-harness-workstation/0.1.2-alpha.1/data.yml
+++ b/apps/deepseek-harness-workstation/0.1.2-alpha.1/data.yml
@@ -1,0 +1,181 @@
+additionalProperties:
+  formFields:
+    - envKey: PANEL_APP_PORT_HTTP
+      type: number
+      required: true
+      default: 56789
+      rule: paramPort
+      edit: true
+      labelZh: Web 访问端口
+      labelEn: Web Port
+      label:
+        en: Web Port
+        zh: Web 访问端口
+        zh-Hant: Web 訪問端口
+        ja: Web ポート
+        ko: 웹 포트
+        ru: Веб-порт
+        ms: Port Web
+        pt-br: Porta Web
+    - envKey: TZ
+      type: text
+      required: true
+      default: Asia/Shanghai
+      edit: true
+      labelZh: 时区
+      labelEn: Timezone
+      label:
+        en: Timezone
+        zh: 时区
+        zh-Hant: 時區
+        ja: タイムゾーン
+        ko: 시간대
+        ru: Часовой пояс
+        ms: Zon waktu
+        pt-br: Fuso horário
+    - envKey: DSH_PUBLIC_URL
+      type: text
+      required: true
+      default: ""
+      edit: true
+      labelZh: 外部 HTTPS 地址
+      labelEn: External HTTPS URL
+      label:
+        en: External HTTPS URL
+        zh: 外部 HTTPS 地址
+        zh-Hant: 外部 HTTPS 位址
+        ja: 外部 HTTPS URL
+        ko: 외부 HTTPS URL
+        ru: Внешний HTTPS-адрес
+        ms: URL HTTPS Luaran
+        pt-br: URL HTTPS externa
+      description:
+        en: Enter the complete browser origin, for example https://dsh.example.com. Paths are not supported.
+        zh: 输入浏览器使用的完整 Origin，例如 https://dsh.example.com；不支持子路径。
+    - envKey: DSH_AUTH_USERNAME
+      type: text
+      required: true
+      default: admin
+      edit: true
+      labelZh: 登录用户名
+      labelEn: Login Username
+      label:
+        en: Login Username
+        zh: 登录用户名
+        zh-Hant: 登入使用者名稱
+        ja: ログインユーザー名
+        ko: 로그인 사용자 이름
+        ru: Имя пользователя
+        ms: Nama Pengguna Log Masuk
+        pt-br: Nome de usuário de login
+    - envKey: DSH_AUTH_PASSWORD
+      type: password
+      required: true
+      default: ""
+      edit: true
+      labelZh: 登录密码
+      labelEn: Login Password
+      label:
+        en: Login Password
+        zh: 登录密码
+        zh-Hant: 登入密碼
+        ja: ログインパスワード
+        ko: 로그인 비밀번호
+        ru: Пароль для входа
+        ms: Kata Laluan Log Masuk
+        pt-br: Senha de login
+      description:
+        en: Use at least 12 characters. The image stores a bcrypt hash in its authentication database, while the submitted plaintext value remains visible to host, 1Panel, and Docker administrators.
+        zh: 至少使用 12 个字符；镜像会在鉴权数据库中保存 bcrypt 哈希，但宿主、1Panel 与 Docker 管理员仍可读取提交的明文值。
+    - envKey: DSH_AUTH_TOKEN_LIFETIME
+      type: select
+      required: true
+      default: "604800"
+      edit: true
+      labelZh: 登录会话有效期
+      labelEn: Login Session Lifetime
+      label:
+        en: Login Session Lifetime
+        zh: 登录会话有效期
+        zh-Hant: 登入工作階段有效期
+        ja: ログインセッション有効期間
+        ko: 로그인 세션 유효 기간
+        ru: Срок действия сеанса
+        ms: Tempoh Sesi Log Masuk
+        pt-br: Duração da sessão de login
+      description:
+        en: The token is not renewed automatically. When it expires, the browser must sign in again.
+        zh: 登录令牌不会自动续期；到期后浏览器需要重新登录。
+      values:
+        - label: 1 hour
+          value: "3600"
+        - label: 8 hours
+          value: "28800"
+        - label: 24 hours
+          value: "86400"
+        - label: 7 days
+          value: "604800"
+        - label: 30 days
+          value: "2592000"
+    - envKey: CADDY_TRUSTED_PROXIES
+      type: text
+      required: true
+      default: private_ranges
+      edit: true
+      labelZh: 可信代理范围
+      labelEn: Trusted Proxy Ranges
+      label:
+        en: Trusted Proxy Ranges
+        zh: 可信代理范围
+        zh-Hant: 受信任代理範圍
+        ja: 信頼済みプロキシ範囲
+        ko: 신뢰할 수 있는 프록시 범위
+        ru: Диапазоны доверенных прокси
+        ms: Julat Proksi Dipercayai
+        pt-br: Faixas de proxies confiáveis
+      description:
+        en: Use space-separated CIDRs or private_ranges. Keep private_ranges behind 1Panel/OpenResty; use none only when clients connect directly to Caddy.
+        zh: 使用空格分隔的 CIDR 或 private_ranges。通过 1Panel/OpenResty 反向代理时保留 private_ranges；仅在客户端直连 Caddy 时使用 none。
+    - envKey: DSH_TRUSTED_HOSTS
+      type: text
+      required: false
+      default: ""
+      edit: true
+      labelZh: 附加可信主机
+      labelEn: Additional Trusted Hosts
+      label:
+        en: Additional Trusted Hosts
+        zh: 附加可信主机
+        zh-Hant: 附加受信任主機
+        ja: 追加の信頼済みホスト
+        ko: 추가 신뢰 호스트
+        ru: Дополнительные доверенные хосты
+        ms: Hos Dipercayai Tambahan
+        pt-br: Hosts confiáveis adicionais
+      description:
+        en: Optional comma-separated host authorities without a scheme. The authority from the external URL is trusted automatically.
+        zh: 可选的逗号分隔主机 authority，不要包含协议；外部地址中的 authority 会自动加入可信列表。
+    - envKey: DOCKER_SOCK_PATH
+      type: select
+      required: true
+      default: /dev/null
+      edit: true
+      labelZh: Docker 套接字访问
+      labelEn: Docker Socket Access
+      label:
+        en: Docker Socket Access
+        zh: Docker 套接字访问
+        zh-Hant: Docker 通訊端存取
+        ja: Docker ソケットアクセス
+        ko: Docker 소켓 접근
+        ru: Доступ к сокету Docker
+        ms: Akses Soket Docker
+        pt-br: Acesso ao socket do Docker
+      description:
+        en: Disabled is the safe default. Enabling grants the workstation effective control of the host Docker daemon.
+        zh: 默认禁用最安全；启用后工作站可有效控制宿主 Docker 守护进程。
+      values:
+        - label: Disabled
+          value: /dev/null
+        - label: Enabled (/var/run/docker.sock)
+          value: /var/run/docker.sock

--- a/apps/deepseek-harness-workstation/0.1.2-alpha.1/docker-compose.yml
+++ b/apps/deepseek-harness-workstation/0.1.2-alpha.1/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   deepseek-harness-workstation:
-    image: "ghcr.io/okxlin/deepseek-harness:workstation"
+    image: "ghcr.io/okxlin/deepseek-harness:0.1.2-alpha.1-workstation"
     container_name: ${CONTAINER_NAME}
     restart: unless-stopped
     labels:

--- a/apps/deepseek-harness-workstation/0.1.2-alpha.1/scripts/init.sh
+++ b/apps/deepseek-harness-workstation/0.1.2-alpha.1/scripts/init.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+exit 0

--- a/apps/deepseek-harness-workstation/0.1.2-alpha.1/scripts/uninstall.sh
+++ b/apps/deepseek-harness-workstation/0.1.2-alpha.1/scripts/uninstall.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+cd "$ROOT_DIR"
+if docker compose version >/dev/null 2>&1; then
+  docker compose down --remove-orphans
+elif docker-compose version >/dev/null 2>&1; then
+  docker-compose down --remove-orphans
+else
+  echo "Docker Compose is not available" >&2
+  exit 1
+fi
+
+echo "Compose resources were removed. Persistent ./data/data, ./data/workspace, and dsh-home are preserved."

--- a/apps/deepseek-harness-workstation/0.1.2-alpha.1/scripts/upgrade.sh
+++ b/apps/deepseek-harness-workstation/0.1.2-alpha.1/scripts/upgrade.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "DeepSeek Harness Workstation keeps application state under ./data/data:/data."
+echo "If legacy state exists in dsh-home:/home/node/.local/share/deepseek-harness, the image migrates it to /data on first startup when /data/auth is empty."
+exit 0

--- a/apps/deepseek-harness-workstation/README.md
+++ b/apps/deepseek-harness-workstation/README.md
@@ -82,7 +82,7 @@ http://127.0.0.1:56789
 
 从旧版工作站布局升级时，如果 `/data/auth` 为空，镜像入口会在首次启动时把 `dsh-home:/home/node/.local/share/deepseek-harness` 中的旧鉴权、Caddy 和 DSH 状态复制到 `/data`。迁移不会删除旧 HOME 数据；请先备份 `./data/data` 和 `dsh-home`，确认新版本启动正常后再自行清理旧副本。
 
-从旧版 AppStore 包升级时，已有 `.env` 通常不包含 `CADDY_TRUSTED_PROXIES`。新 Compose 会自动使用 `private_ranges`，因此标准 1Panel/OpenResty 部署无需手工补写该变量，也不会改变 `/data`、`/home/node` 或 `/workspace` 的挂载和数据。升级后可在应用参数中按实际代理链调整该值。
+从旧版 AppStore 包升级时，已有 `.env` 通常不包含 `CADDY_TRUSTED_PROXIES`。新 Compose 会自动使用 `private_ranges`，因此标准 1Panel/OpenResty 部署无需手工补写该变量，也不会改变 `/data`、`/home/node` 或 `/workspace` 的挂载和数据。升级后可在应用参数中按实际代理链调整该值。`0.1.2-alpha.1` 使用新的 `ghcr.io/okxlin/deepseek-harness` 工作站镜像，现有安装可以直接执行 1Panel 应用升级；升级前仍建议备份应用目录和 `dsh-home`，不要删除旧卷。
 
 1Panel 的应用备份覆盖应用安装目录，因此会包含 `./data/data` 和 `./data/workspace`。独立的 HOME named volume 不在应用目录内，升级、卸载或迁移前如需保留用户安装的工具和缓存，请停止应用并单独备份 `dsh-home`：
 
@@ -90,7 +90,7 @@ http://127.0.0.1:56789
 docker run --rm --entrypoint tar \
   -v dsh-home:/source:ro \
   -v "$PWD":/backup \
-  moelin/deepseek-harness:workstation \
+  ghcr.io/okxlin/deepseek-harness:workstation \
   -C /source -czf /backup/dsh-home.tar.gz .
 ```
 
@@ -100,7 +100,7 @@ docker run --rm --entrypoint tar \
 docker run --rm --entrypoint tar \
   -v dsh-home:/target \
   -v "$PWD":/backup:ro \
-  moelin/deepseek-harness:workstation \
+  ghcr.io/okxlin/deepseek-harness:workstation \
   -C /target -xzf /backup/dsh-home.tar.gz
 ```
 
@@ -130,7 +130,7 @@ The image limits username-stage POSTs to 30 per minute and password-stage POSTs 
 
 ## 镜像与源码
 
-- 应用版本：滚动版本 `latest` 与对应的固定版本目录
-- 镜像：`latest` 使用 `moelin/deepseek-harness:workstation`，固定版本使用匹配的 `<版本>-workstation` tag
+- 应用版本：滚动版本 `latest` 与固定版本 `0.1.2-alpha.1`
+- 镜像：`latest` 使用 `ghcr.io/okxlin/deepseek-harness:workstation`，固定版本使用匹配的 `<版本>-workstation` tag
 - DeepSeek Harness：<https://github.com/deepseek-ai/deepseek-harness>
 - 镜像构建源码：<https://github.com/okxlin/release-factory/blob/main/deepseek-harness-builder/README.md>


### PR DESCRIPTION
## Summary

- Add the fixed `0.1.2-alpha.1` DeepSeek Harness Workstation version.
- Update the `latest` channel to the matching floating workstation tag.
- Use the multi-architecture images published by `okxlin/release-factory` under `ghcr.io/okxlin/deepseek-harness`.
- Preserve the existing service name, environment keys, `/data`, `/workspace`, and `dsh-home` volume so existing installations can upgrade in place.
- Keep historical version directories unchanged for reproducible rollback.

## Image provenance

- Upstream source: `deepseek-ai/deepseek-harness` tag `dsh-v0.1.2-alpha.1`, commit `cd5ef8148158c3a752a658978873241fdf8e2bbc`.
- Builder revision: `okxlin/release-factory` commit `92bd8ba316ad342118fa7b9188a211e683b9643b`.
- Successful workstation build: https://github.com/okxlin/release-factory/actions/runs/33230910350
- OCI index digest: `sha256:13da39612dd519cebf8ef0e28d42929fd774a4cd0f61be89ee984629a8cf1eb9`
- Platform manifests: amd64 `sha256:7139aaed2be8c3911b5232f7034b40e309fd2bc0f51d1fa59352ef43fbd1f2bf`; arm64 `sha256:5a409fd566d61686890a1b21e6b32f753b119ca863447d5755b65eab58cac22a`.

## Validation

- `validate-v2.sh --strict-store --source-evidence-mode required --i18n-mode strict --require-delivery-evidence` passed for both `0.1.2-alpha.1` and `latest` using task-local hash-bound evidence.
- Environment sample closure, Compose rendering, shell syntax, and `git diff --check` passed.
- Real 1Panel v2 smoke passed the upgrade path `0.1.1-rc.2` → `0.1.2-alpha.1`, including source/target runtime HTTP checks, restart, uninstall, and cleanup.
