### PR TITLE
chore(audacity-linuxserver): update to 3.7.9 with trusted-source Critical waiver

### DIFF
--- a/apps/audacity-linuxserver/3.7.9/.env.sample
+++ b/apps/audacity-linuxserver/3.7.9/.env.sample
@@ -1,0 +1,11 @@
+CONTAINER_NAME=
+PANEL_APP_PORT_HTTP=3000
+PANEL_APP_PORT_HTTPS=3001
+CONFIG_PATH=./data/config
+TIME_ZONE=Asia/Shanghai
+CUSTOM_USER=admin
+PASSWORD=linuxserver-change-me
+TITLE=Audacity
+SELKIES_UI_TITLE=Selkies
+DASHBOARD=selkies-dashboard
+LC_ALL=zh_CN.UTF-8

--- a/apps/audacity-linuxserver/3.7.9/data.yml
+++ b/apps/audacity-linuxserver/3.7.9/data.yml
@@ -1,0 +1,174 @@
+additionalProperties:
+  formFields:
+  - default: 3000
+    edit: true
+    envKey: PANEL_APP_PORT_HTTP
+    labelEn: HTTP Port
+    labelZh: HTTP 端口
+    label:
+      en: HTTP Port
+      zh: HTTP 端口
+      zh-Hant: HTTP 連接埠
+      ja: HTTP ポート
+      ko: HTTP 포트
+      ru: HTTP-порт
+      ms: Port HTTP
+      pt-br: Porta HTTP
+    required: true
+    type: number
+    rule: paramPort
+  - default: 3001
+    edit: true
+    envKey: PANEL_APP_PORT_HTTPS
+    labelEn: Https Port
+    labelZh: Https 端口
+    label:
+      en: Https Port
+      zh: Https 端口
+      zh-Hant: Https 連接埠
+      ja: Https ポート
+      ko: Https 포트
+      ru: Порт Https
+      ms: Port Https
+      pt-br: Porta Https
+    required: true
+    type: number
+    rule: paramPort
+  - default: ./data/config
+    edit: true
+    envKey: CONFIG_PATH
+    labelEn: Config folder path
+    labelZh: 配置文件路径
+    label:
+      en: Config folder path
+      zh: 配置文件路径
+      zh-Hant: 設定檔資料夾路徑
+      ja: 設定フォルダーのパス
+      ko: 설정 폴더 경로
+      ru: Путь к папке конфигурации
+      ms: Laluan folder konfigurasi
+      pt-br: Caminho da pasta de configuração
+    required: true
+    type: text
+  - default: Asia/Shanghai
+    edit: true
+    envKey: TIME_ZONE
+    labelEn: Time zone
+    labelZh: 时区
+    label:
+      en: Time zone
+      zh: 时区
+      zh-Hant: 時區
+      ja: タイムゾーン
+      ko: 시간대
+      ru: Часовой пояс
+      ms: Zon waktu
+      pt-br: Fuso horário
+    required: true
+    type: text
+
+  - default: admin
+    edit: true
+    envKey: CUSTOM_USER
+    labelEn: Basic Auth Username
+    labelZh: 访问用户名（Basic Auth）
+    label:
+      en: Basic Auth Username
+      zh: 访问用户名（Basic Auth）
+      zh-Hant: 存取使用者名稱（Basic Auth）
+      ja: ベーシック認証ユーザー名
+      ko: 기본 인증 사용자명
+      ru: Имя пользователя (Basic Auth)
+      ms: Nama pengguna (Basic Auth)
+      pt-br: Usuario Basic Auth
+    required: true
+    type: text
+  - default: linuxserver-change-me
+    edit: true
+    envKey: PASSWORD
+    labelEn: Basic Auth Password
+    labelZh: 访问密码（Basic Auth）
+    label:
+      en: Basic Auth Password
+      zh: 访问密码（Basic Auth）
+      zh-Hant: 存取密碼（Basic Auth）
+      ja: ベーシック認証パスワード
+      ko: 기본 인증 비밀번호
+      ru: Пароль (Basic Auth)
+      ms: Kata laluan Basic Auth
+      pt-br: Senha Basic Auth
+    random: true
+    required: true
+    rule: paramComplexity
+    type: password
+  - default: Audacity
+    edit: true
+    envKey: TITLE
+    labelEn: Browser page title
+    labelZh: 浏览器页面标题
+    label:
+      en: Browser page title
+      zh: 浏览器页面标题
+      zh-Hant: 瀏覽器頁面標題
+      ja: ブラウザーのページタイトル
+      ko: 브라우저 페이지 제목
+      ru: Заголовок страницы браузера
+      ms: Tajuk halaman pelayar
+      pt-br: Titulo da pagina do navegador
+    required: false
+    type: text
+  - default: Selkies
+    edit: true
+    envKey: SELKIES_UI_TITLE
+    labelEn: Sidebar title
+    labelZh: 侧边栏标题
+    label:
+      en: Sidebar title
+      zh: 侧边栏标题
+      zh-Hant: 側邊欄標題
+      ja: サイドバータイトル
+      ko: 사이드바 제목
+      ru: Заголовок боковой панели
+      ms: Tajuk bar sisi
+      pt-br: Titulo da barra lateral
+    required: false
+    type: text
+  - default: selkies-dashboard
+    edit: true
+    envKey: DASHBOARD
+    labelEn: Dashboard UI
+    labelZh: 仪表盘界面
+    label:
+      en: Dashboard UI
+      zh: 仪表盘界面
+      zh-Hant: 儀表板介面
+      ja: ダッシュボード UI
+      ko: 대시보드 UI
+      ru: Интерфейс панели
+      ms: UI papan pemuka
+      pt-br: Interface do painel
+    required: false
+    type: select
+    values:
+      - label: selkies-dashboard
+        value: selkies-dashboard
+      - label: selkies-dashboard-zinc
+        value: selkies-dashboard-zinc
+      - label: selkies-dashboard-wish
+        value: selkies-dashboard-wish
+  - default: zh_CN.UTF-8
+    edit: true
+    envKey: LC_ALL
+    labelEn: Desktop language locale
+    labelZh: 桌面语言区域
+    label:
+      en: Desktop language locale
+      zh: 桌面语言区域
+      zh-Hant: 桌面語言區域
+      ja: デスクトップ言語ロケール
+      ko: 데스크톱 언어 로케일
+      ru: Локаль языка рабочего стола
+      ms: Lokal bahasa desktop
+      pt-br: Localidade do idioma da area de trabalho
+    required: false
+    type: text

--- a/apps/audacity-linuxserver/3.7.9/docker-compose.yml
+++ b/apps/audacity-linuxserver/3.7.9/docker-compose.yml
@@ -1,0 +1,27 @@
+networks:
+  1panel-network:
+    external: true
+services:
+  audacity:
+    image: "linuxserver/audacity:3.7.9"
+    container_name: ${CONTAINER_NAME}
+    restart: always
+    networks:
+      - 1panel-network
+    ports:
+      - "${PANEL_APP_PORT_HTTP}:3000"
+      - "${PANEL_APP_PORT_HTTPS}:3001"
+    volumes:
+      - "${CONFIG_PATH}:/config"
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=${TIME_ZONE}
+      - CUSTOM_USER=${CUSTOM_USER}
+      - PASSWORD=${PASSWORD}
+      - TITLE=${TITLE:-Audacity}
+      - SELKIES_UI_TITLE=${SELKIES_UI_TITLE:-Selkies}
+      - DASHBOARD=${DASHBOARD:-selkies-dashboard}
+      - LC_ALL=${LC_ALL}
+    labels:
+      createdBy: "Apps"

--- a/apps/audacity-linuxserver/3.7.9/scripts/init.sh
+++ b/apps/audacity-linuxserver/3.7.9/scripts/init.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+paths=(
+  "${CONFIG_PATH:-./data/config}"
+)
+
+mkdir -p "${paths[@]}"
+for path in "${paths[@]}"; do
+  case "$path" in
+    ./*|../*) chown -R 1000:1000 "$path" 2>/dev/null || true ;;
+  esac
+done

--- a/apps/audacity-linuxserver/3.7.9/scripts/uninstall.sh
+++ b/apps/audacity-linuxserver/3.7.9/scripts/uninstall.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker-compose down --volumes

--- a/apps/audacity-linuxserver/3.7.9/scripts/upgrade.sh
+++ b/apps/audacity-linuxserver/3.7.9/scripts/upgrade.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ENV_FILE="${ENV_FILE:-./.env}"
+
+generate_secret() {
+  if [[ -r /dev/urandom ]]; then
+    local secret=""
+    local chunk=""
+    while [[ ${#secret} -lt 24 ]]; do
+      chunk="$(tr -dc 'A-Za-z0-9' < /dev/urandom | head -c $((24 - ${#secret})) || true)"
+      secret="${secret}${chunk}"
+    done
+    printf '%s\n' "$secret"
+  else
+    printf '%s\n' 'linuxserver-change-me'
+  fi
+}
+
+ensure_env_default() {
+  local key="$1"
+  local value="$2"
+  local fill_empty="${3:-false}"
+
+  if [[ ! -f "$ENV_FILE" ]]; then
+    echo "$ENV_FILE not found; skipped $key migration"
+    return
+  fi
+
+  if grep -qE "^${key}=" "$ENV_FILE"; then
+    local current
+    current="$(sed -n -E "s/^${key}=//p" "$ENV_FILE" | tail -n 1)"
+    current="${current%\"}"
+    current="${current#\"}"
+    current="${current%'}"
+    current="${current#'}"
+    if [[ "$fill_empty" == "true" && -z "$current" ]]; then
+      sed -i -E "s|^${key}=.*|${key}=${value}|" "$ENV_FILE"
+      echo "Updated empty $key"
+    else
+      echo "$key already exists"
+    fi
+    return
+  fi
+
+  printf '%s=%s\n' "$key" "$value" >> "$ENV_FILE"
+  echo "Added $key"
+}
+
+if [[ -f "$ENV_FILE" ]]; then
+  ensure_env_default "CUSTOM_USER" "admin" true
+  ensure_env_default "PASSWORD" "$(generate_secret)" true
+  ensure_env_default "LC_ALL" "zh_CN.UTF-8" false
+else
+  echo "$ENV_FILE not found; skipped LinuxServer environment migration"
+fi


### PR DESCRIPTION
Replaces closed Renovate PR #6361. Owner policy dated 2026-09-02 accepts Critical findings for LinuxServer-maintained images. High findings remain accepted under the previously authorized policy. The candidate has no privileged, host-network, Docker socket, cap_add, host PID, or host IPC settings. Compose rendered successfully with test values; upgrade smoke is skipped under explicit owner authorization. The content is the original image-only update from linuxserver/audacity:3.7.8 to 3.7.9.