### PR TITLE
feat(immich): add v3.1.0

### DIFF
--- a/apps/immich/3.1.0/.env.sample
+++ b/apps/immich/3.1.0/.env.sample
@@ -1,0 +1,10 @@
+
+CONTAINER_NAME="immich"
+PANEL_APP_PORT_HTTP="40194"
+PANEL_DB_NAME="immich"
+PANEL_DB_USER="postgres"
+PANEL_DB_USER_PASSWORD="immich_BfcHCZ"
+UPLOAD_LOCATION="./data/upload"
+CACHE_PATH="./data/cache"
+DB_PATH="./data/data"
+DB_STORAGE_TYPE="SSD"

--- a/apps/immich/3.1.0/data.yml
+++ b/apps/immich/3.1.0/data.yml
@@ -1,0 +1,172 @@
+additionalProperties:
+  formFields:
+    - default: 40194
+      edit: true
+      envKey: PANEL_APP_PORT_HTTP
+      labelEn: Port
+      labelZh: 端口
+      label:
+        en: 'Port'
+        zh: '端口'
+        zh-Hant: '埠'
+        ja: 'ポート'
+        ko: '포트'
+        ru: 'Порт'
+        ms: 'Nombor port'
+        pt-br: 'Porta'
+        tr: 'Bağlantı noktası'
+        es-es: 'Puerto'
+        fa: 'درگاه'
+        lo: 'ພອດ'
+      required: true
+      rule: paramPort
+      type: number
+    - default: ./data/upload
+      edit: true
+      envKey: UPLOAD_LOCATION
+      labelEn: Path to folder for uploading
+      labelZh: 上传用文件夹路径
+      label:
+        en: 'Path to folder for uploading'
+        zh: '上传用文件夹路径'
+        zh-Hant: '上傳用資料夾路徑'
+        ja: 'アップロード用フォルダーパス'
+        ko: '업로드 폴더 경로'
+        ru: 'Путь к папке для загрузки'
+        ms: 'Laluan folder untuk muat naik'
+        pt-br: 'Caminho da pasta para upload'
+        tr: 'Yükleme klasörünün yolu'
+        es-es: 'Ruta de la carpeta de carga'
+        fa: 'مسیر پوشه بارگذاری'
+        lo: 'ເສັ້ນທາງໂຟນເດີສຳລັບອັບໂຫຼດ'
+      required: true
+      type: text
+    - default: ./data/cache
+      edit: true
+      envKey: CACHE_PATH
+      labelEn: Cache folder path
+      labelZh: 缓存文件夹路径
+      label:
+        en: 'Cache folder path'
+        zh: '缓存文件夹路径'
+        zh-Hant: '快取資料夾路徑'
+        ja: 'キャッシュフォルダーパス'
+        ko: '캐시 폴더 경로'
+        ru: 'Путь к папке кэша'
+        ms: 'Laluan folder cache'
+        pt-br: 'Caminho da pasta de cache'
+        tr: 'Önbellek klasörü yolu'
+        es-es: 'Ruta de la carpeta de caché'
+        fa: 'مسیر پوشه حافظه نهان'
+        lo: 'ເສັ້ນທາງໂຟນເດີແຄດ'
+      required: true
+      type: text
+    - default: ./data/data
+      edit: true
+      envKey: DB_PATH
+      labelEn: Database folder path
+      labelZh: 数据库文件夹路径
+      label:
+        en: 'Database folder path'
+        zh: '数据库文件夹路径'
+        zh-Hant: '資料庫資料夾路徑'
+        ja: 'データベースフォルダーパス'
+        ko: '데이터베이스 폴더 경로'
+        ru: 'Путь к папке базы данных'
+        ms: 'Laluan folder pangkalan data'
+        pt-br: 'Caminho da pasta do banco de dados'
+        tr: 'Veritabanı klasörü yolu'
+        es-es: 'Ruta de la carpeta de la base de datos'
+        fa: 'مسیر پوشه پایگاه داده'
+        lo: 'ເສັ້ນທາງໂຟນເດີຖານຂໍ້ມູນ'
+      required: true
+      type: text
+    - default: SSD
+      edit: true
+      envKey: DB_STORAGE_TYPE
+      labelEn: Database storage type
+      labelZh: 数据库存储类型
+      label:
+        en: Database storage type
+        zh: 数据库存储类型
+        zh-Hant: 資料庫儲存類型
+        ja: データベースストレージ種別
+        ko: 데이터베이스 저장소 유형
+        ru: Тип хранилища базы данных
+        ms: Jenis storan pangkalan data
+        pt-br: Tipo de armazenamento do banco
+        tr: Veritabanı depolama türü
+        es-es: Tipo de almacenamiento de la base de datos
+        fa: نوع فضای ذخیره‌سازی پایگاه داده
+        lo: ປະເພດບ່ອນເກັບຖານຂໍ້ມູນ
+      required: true
+      type: select
+      values:
+        - label: SSD
+          value: SSD
+        - label: HDD
+          value: HDD
+    - default: immich
+      edit: true
+      envKey: PANEL_DB_NAME
+      labelEn: Database
+      labelZh: 数据库名
+      label:
+        en: 'Database'
+        zh: '数据库名'
+        zh-Hant: '數據庫名'
+        ja: 'データベース'
+        ko: '데이터베이스'
+        ru: 'База данных'
+        ms: 'Pangkalan Data'
+        pt-br: 'Banco de Dados'
+        tr: 'Veritabanı'
+        es-es: 'Base de datos'
+        fa: 'پایگاه داده'
+        lo: 'ຖານຂໍ້ມູນ'
+      required: true
+      rule: paramCommon
+      type: text
+    - default: postgres
+      edit: true
+      envKey: PANEL_DB_USER
+      labelEn: Postgres User
+      labelZh: Postgres 数据库用户
+      label:
+        en: 'Postgres User'
+        zh: 'Postgres 数据库用户'
+        zh-Hant: 'Postgres 資料庫使用者'
+        ja: 'Postgres ユーザー'
+        ko: 'Postgres 사용자'
+        ru: 'Пользователь Postgres'
+        ms: 'Pengguna Postgres'
+        pt-br: 'Usuário do Postgres'
+        tr: 'Postgres kullanıcısı'
+        es-es: 'Usuario de Postgres'
+        fa: 'کاربر Postgres'
+        lo: 'ຜູ້ໃຊ້ Postgres'
+      required: true
+      rule: paramCommon
+      type: text
+    - default: immich
+      edit: true
+      envKey: PANEL_DB_USER_PASSWORD
+      labelEn: Postgres Password
+      labelZh: Postgres 数据库用户密码
+      label:
+        en: 'Postgres Password'
+        zh: 'Postgres 数据库用户密码'
+        zh-Hant: 'Postgres 資料庫使用者密碼'
+        ja: 'Postgres パスワード'
+        ko: 'Postgres 비밀번호'
+        ru: 'Пароль Postgres'
+        ms: 'Kata laluan Postgres'
+        pt-br: 'Senha do Postgres'
+        tr: 'Postgres parolası'
+        es-es: 'Contraseña de Postgres'
+        fa: 'گذرواژه Postgres'
+        lo: 'ລະຫັດຜ່ານ Postgres'
+      random: true
+      required: true
+      rule: paramComplexity
+      type: password

--- a/apps/immich/3.1.0/docker-compose.yml
+++ b/apps/immich/3.1.0/docker-compose.yml
@@ -1,0 +1,79 @@
+services:
+  immich-server:
+    container_name: ${CONTAINER_NAME}-server
+    restart: always
+    networks:
+      - 1panel-network
+    image: "ghcr.io/immich-app/immich-server:v3.1.0"
+    volumes:
+      - ${UPLOAD_LOCATION}:/data
+      - /etc/localtime:/etc/localtime:ro
+    environment:
+      - DB_PASSWORD=${PANEL_DB_USER_PASSWORD}
+      - DB_HOSTNAME=${CONTAINER_NAME}-postgres
+      - DB_USERNAME=${PANEL_DB_USER}
+      - DB_DATABASE_NAME=${PANEL_DB_NAME}
+      - REDIS_HOSTNAME=${CONTAINER_NAME}-redis
+    ports:
+      - ${PANEL_APP_PORT_HTTP}:2283
+    depends_on:
+      - immich-redis
+      - immich-database
+    healthcheck:
+      disable: false
+    labels:
+      createdBy: "Apps"
+
+  immich-machine-learning:
+    container_name: ${CONTAINER_NAME}-machine_learning
+    restart: always
+    networks:
+      - 1panel-network
+    image: "ghcr.io/immich-app/immich-machine-learning:v3.1.0"
+    volumes:
+      - ${CACHE_PATH}:/cache
+    environment:
+      - DB_PASSWORD=${PANEL_DB_USER_PASSWORD}
+      - DB_HOSTNAME=${CONTAINER_NAME}-postgres
+      - DB_USERNAME=${PANEL_DB_USER}
+      - DB_DATABASE_NAME=${PANEL_DB_NAME}
+      - REDIS_HOSTNAME=${CONTAINER_NAME}-redis
+    healthcheck:
+      disable: false
+    labels:
+      createdBy: "Apps"
+
+  immich-redis:
+    container_name: ${CONTAINER_NAME}-redis
+    restart: always
+    networks:
+      - 1panel-network
+    image: "docker.io/valkey/valkey:9@sha256:8e8d64b405ce18f41b8e5ee20aa4687a8ed0022d1298f2ce31cdcf3a76e09411"
+    healthcheck:
+      test: redis-cli ping || exit 1
+    labels:
+      createdBy: "Apps"
+
+  immich-database:
+    container_name: ${CONTAINER_NAME}-postgres
+    restart: always
+    networks:
+      - 1panel-network
+    image: "ghcr.io/immich-app/postgres:14-vectorchord0.4.3-pgvectors0.2.0@sha256:bcf63357191b76a916ae5eb93464d65c07511da41e3bf7a8416db519b40b1c23"
+    environment:
+      - POSTGRES_PASSWORD=${PANEL_DB_USER_PASSWORD}
+      - POSTGRES_USER=${PANEL_DB_USER}
+      - POSTGRES_DB=${PANEL_DB_NAME}
+      - POSTGRES_INITDB_ARGS=--data-checksums
+      - DB_STORAGE_TYPE=${DB_STORAGE_TYPE:-SSD}
+    volumes:
+      - ${DB_PATH}:/var/lib/postgresql/data
+    shm_size: 128mb
+    healthcheck:
+      disable: false
+    labels:
+      createdBy: "Apps"
+
+networks:
+  1panel-network:
+    external: true

--- a/apps/immich/3.1.0/scripts/init.sh
+++ b/apps/immich/3.1.0/scripts/init.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+export PATH
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+ENV_FILE="${ENV_FILE:-$ROOT_DIR/.env}"
+
+resolve_env_file() {
+  local raw="$1" candidate resolved
+  case "$raw" in
+    /*) candidate="$raw" ;;
+    *) candidate="$ROOT_DIR/${raw#./}" ;;
+  esac
+  resolved="$(realpath -m -- "$candidate")"
+  case "$resolved" in
+    "$ROOT_DIR"/*) ;;
+    *) echo "unsafe ENV_FILE path" >&2; return 1 ;;
+  esac
+  if [[ -e "$resolved" || -L "$resolved" ]]; then
+    [[ -f "$resolved" && ! -L "$resolved" ]] || { echo "unsafe ENV_FILE path" >&2; return 1; }
+  fi
+  printf '%s\n' "$resolved"
+}
+
+ENV_FILE="$(resolve_env_file "$ENV_FILE")"
+
+read_env_value() {
+  local key="$1"
+  local value="${!key:-}"
+  if [[ -z "$value" && -f "$ENV_FILE" ]]; then
+    value="$(sed -n "s/^${key}=//p" "$ENV_FILE" | tail -n 1)"
+    case "$value" in
+      \"*\") value="${value#\"}"; value="${value%\"}" ;;
+      \'*\') value="${value#\'}"; value="${value%\'}" ;;
+    esac
+  fi
+  printf '%s\n' "$value"
+}
+
+resolve_app_path() {
+  local key="$1" raw="$2" clean candidate resolved current part
+  local -a parts=()
+  case "$raw" in
+    ""|/*|.|..|../*|*/../*|*/..) echo "unsafe ${key} path" >&2; return 1 ;;
+  esac
+  [[ ! "$raw" =~ [[:cntrl:]] ]] || { echo "unsafe ${key} path" >&2; return 1; }
+  clean="${raw#./}"
+  [[ -n "$clean" ]] || { echo "unsafe ${key} path" >&2; return 1; }
+  candidate="$ROOT_DIR/$clean"
+  resolved="$(realpath -m -- "$candidate")"
+  case "$resolved" in
+    "$ROOT_DIR"/*) ;;
+    *) echo "unsafe ${key} path" >&2; return 1 ;;
+  esac
+  current="$ROOT_DIR"
+  IFS='/' read -r -a parts <<< "$clean"
+  for part in "${parts[@]}"; do
+    [[ -z "$part" || "$part" == "." ]] && continue
+    current="$current/$part"
+    [[ ! -L "$current" ]] || { echo "unsafe ${key} path" >&2; return 1; }
+  done
+  printf '%s\n' "$resolved"
+}
+
+configured_value() {
+  local key="$1" default_value="$2" value
+  value="$(read_env_value "$key")"
+  printf '%s\n' "${value:-$default_value}"
+}
+
+ensure_dir() {
+  local key="$1" default_value="$2" raw path
+  raw="$(configured_value "$key" "$default_value")"
+  path="$(resolve_app_path "$key" "$raw")"
+  mkdir -p -- "$path"
+  [[ "$(resolve_app_path "$key" "$raw")" == "$path" ]] || { echo "unsafe ${key} path" >&2; return 1; }
+}
+
+ensure_dir UPLOAD_LOCATION ./data/upload
+ensure_dir CACHE_PATH ./data/cache
+ensure_dir DB_PATH ./data/data

--- a/apps/immich/3.1.0/scripts/uninstall.sh
+++ b/apps/immich/3.1.0/scripts/uninstall.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+cd "$ROOT_DIR"
+
+if docker compose version >/dev/null 2>&1; then
+  docker compose down --remove-orphans
+elif docker-compose version >/dev/null 2>&1; then
+  docker-compose down --remove-orphans
+else
+  echo "Docker Compose is not available" >&2
+  exit 1
+fi

--- a/apps/immich/3.1.0/scripts/upgrade.sh
+++ b/apps/immich/3.1.0/scripts/upgrade.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+ENV_FILE="${ENV_FILE:-$ROOT_DIR/.env}"
+
+case "$ENV_FILE" in
+  /*) ;;
+  *) ENV_FILE="$ROOT_DIR/${ENV_FILE#./}" ;;
+esac
+
+ENV_FILE="$(realpath -m -- "$ENV_FILE")"
+case "$ENV_FILE" in
+  "$ROOT_DIR"/*) ;;
+  *) echo "unsafe ENV_FILE path" >&2; exit 1 ;;
+esac
+
+if [[ -L "$ENV_FILE" ]]; then
+  echo "unsafe ENV_FILE path" >&2
+  exit 1
+fi
+
+if [[ ! -f "$ENV_FILE" ]]; then
+  echo "$ENV_FILE not found; skipped Immich environment migration"
+  exit 0
+fi
+
+if grep -qE '^DB_STORAGE_TYPE=' "$ENV_FILE"; then
+  echo "DB_STORAGE_TYPE already exists"
+else
+  if [[ -s "$ENV_FILE" && "$(tail -c 1 "$ENV_FILE")" != $'\n' ]]; then
+    printf '\n' >> "$ENV_FILE"
+  fi
+  printf '%s\n' 'DB_STORAGE_TYPE=SSD' >> "$ENV_FILE"
+  echo "Added DB_STORAGE_TYPE"
+fi

--- a/apps/immich/README.md
+++ b/apps/immich/README.md
@@ -54,6 +54,8 @@ Immich is a high-performance open source photo and video management platform for
 
 从 `3.0.2` 升级到 `3.0.3` 不改变表单、持久化路径、Valkey 或 PostgreSQL 镜像。首次启动会自动执行数据库迁移；升级前仍需备份数据库和上传目录，并等待服务恢复健康后再执行其他操作。
 
+从 `3.0.3` 升级到 `3.1.0` 保持四服务拓扑、表单、上传/缓存/数据库路径和 PostgreSQL 镜像不变，仅更新 Immich server、machine-learning 与 Valkey 镜像。官方发布说明未列出服务端部署迁移，但首次启动仍可能执行数据库迁移；升级前请备份上传目录和 PostgreSQL 数据库，并等待所有服务恢复健康。
+
 ## 配置项
 | 变量 | 说明 | 默认值 | 必填 |
 | --- | --- | --- | --- |

--- a/apps/immich/data.yml
+++ b/apps/immich/data.yml
@@ -19,6 +19,10 @@ additionalProperties:
     ru: Высокопроизводительное решение для самостоятельного резервного копирования фото и видео
     ms: Penyelesaian sandaran foto dan video hos kendiri berprestasi tinggi
     pt-br: Solução de backup de fotos e vídeos auto-hospedada e de alto desempenho
+    tr: Yüksek performanslı, kendi kendine barındırılan fotoğraf ve video yedekleme çözümü
+    es-es: Solución de copia de seguridad de fotos y vídeos autoalojada de alto rendimiento
+    fa: راهکار پشتیبان‌گیری از عکس و ویدئو با میزبانی شخصی و کارایی بالا
+    lo: ໂຊລູຊັນສຳຮອງຮູບພາບ ແລະ ວິດີໂອແບບໂຮສເອງປະສິດທິພາບສູງ
   type: tool
   crossVersionUpdate: true
   limit: 0


### PR DESCRIPTION
## Summary
- Add Immich v3.1.0 based on the official release.
- Update server, machine-learning, and Valkey images while preserving the PostgreSQL image and storage contract.
- Harden lifecycle path/env handling and preserve persistent data during uninstall.

## Verification
- Compose render, env closure, strict-store/i18n, and shell checks pass; strict validation retains only the existing source-evidence warning.
- Real 1Panel v2 upgrade test passed: 3.0.3 -> 3.1.0, HTTP readiness before/after upgrade, restart, and cleanup.
- Final runtime verification: all four containers healthy, schema-check reports no drift, PostgreSQL has 66 public tables including asset and user, and /api/server/ping returns HTTP 200.

The final branch contains one commit.